### PR TITLE
Conditional execution

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -90,10 +90,10 @@ def filter_combinator(combinator, config):
 def aggregate_input(wildcards):
     """
     Returns input for rule aggregate based on output from checkpoint align_rate.
-    Currently set to generate consensus genome only if at least 1.00% overall alignment rate.
+    Set minimum align rate in config under "min_align_rate".
     """
     with open(checkpoints.align_rate.get(sample=wildcards.sample, reference=wildcards.reference).output[0]) as f:
-        if float(f.read().strip()[:3]) < 1.00:
+        if float(f.read().strip()[:3]) < config["min_align_rate"]:
             return "summary/not_mapped/{reference}/{sample}.txt"
         else:
             return "consensus_genomes/{reference}/{sample}.consensus.fasta"

--- a/config/config.json
+++ b/config/config.json
@@ -8,10 +8,12 @@
   "sample_reference_pairs":
     {
       "S13": ["h3n2_NewYork_392_2004", "h3n2_Texas_50_2012", "h3n2_HongKong_4801_2014"],
-      "S69": ["h3n2_NewYork_392_2004", "h3n2_Texas_50_2012", "h3n2_HongKong_4801_2014"],
+      "S69": ["coronavirusHKU1"],
       "S76": ["h1n1_PuertoRico_8_1934", "h1n1pdm_California_04_2009", "h1n1pdm_Michigan_45_2015"],
       "S78": ["h1n1_PuertoRico_8_1934", "h1n1pdm_California_04_2009", "h1n1pdm_Michigan_45_2015"]
     },
+  "min_align_rate": 
+    1.00,
   "reference_viruses" :
     {
       "1940influenzaB" : {},


### PR DESCRIPTION
This PR addresses the bug where `vcf_to_consensus` errors out when there are low alignment rates.

- Adds a checkpoint after mapping to check overall alignment rate.
- If overall alignment rate does not meet `min-align-rate` set in config, then this particular sample/ref pairing does not go through the rest of the pipeline and gets dumped into `summary/not_mapped/`

@barneypotter24 has tested this branch