### PR TITLE
Improve masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 Assembly pipeline used in the [Seattle Flu Study](https://seattleflu.org/) to build consensus genomes for sequenced samples.
 
-Adapted from Louise Moncla's [Illumina pipline](https://github.com/lmoncla/illumina_pipeline) for influenza snp calling. 
+Adapted from Louise Moncla's [Illumina pipline](https://github.com/lmoncla/illumina_pipeline) for influenza snp calling.
 
 ## Installation
 Install dependencies via Conda by running:
@@ -17,11 +17,11 @@ conda activate seattle-flu
 
 ## Set Up
 ### FASTQ Files
-The pipeline expects 8 total FASTQ files for each individual sample, with Read 1 (R1) and Read 2 (R2) from 4 different lanes. 
+The pipeline expects 8 total FASTQ files for each individual sample, with Read 1 (R1) and Read 2 (R2) from 4 different lanes.
 
 Expected filename format: `318375_S12_L001_R1_001.fastq.gz` where `318375` is the NWGC sample ID.
 
-If the filename does not contain the NWGC sample ID, rename the FASTQ files by using: 
+If the filename does not contain the NWGC sample ID, rename the FASTQ files by using:
 ```
 python scripts/rename_fastq.py
 usage: rename_fastq.py [-h]
@@ -44,7 +44,7 @@ optional arguments:
   -h, --help       show this help message and exit
 ```
 ### Setup Config File
-By default, the pipeline will generate combinations of all samples and references and try to create consensus genomes for all combinations.  
+By default, the pipeline will generate combinations of all samples and references and try to create consensus genomes for all combinations.
 
 Avoid this by specifying specific sample-reference pairs and ignored samples in the config file by using:
 ```
@@ -81,10 +81,10 @@ optional arguments:
 __Note__: This currently only works for flu-positive samples. To add more targets/references, edit `references/target_reference_map.json`.
 
 #### Check Read Pairs
-Embedded in this script is a check to ensure that the reads in R1 and R2 of each sample match. This is to avoid the demultiplexing error described in [this paper](https://www.nature.com/articles/s41588-019-0349-3). If the reads differ by over 20% then the sample will be added to the ignored samples. Redirect the output to a file to keep track of read differences and ignored samples. 
+Embedded in this script is a check to ensure that the reads in R1 and R2 of each sample match. This is to avoid the demultiplexing error described in [this paper](https://www.nature.com/articles/s41588-019-0349-3). If the reads differ by over 20% then the sample will be added to the ignored samples. Redirect the output to a file to keep track of read differences and ignored samples.
 
 ### NWGC ID/SFS UUID key-value pair
-Consensus genome FASTA headers are generated with the NWGC sample ID which then needs to be converted to the SFS UUID in order to be paired with stored metadata. 
+Consensus genome FASTA headers are generated with the NWGC sample ID which then needs to be converted to the SFS UUID in order to be paired with stored metadata.
 
 This is done with the [seqkit replace](https://bioinf.shenwei.me/seqkit/usage/#replace) method, which requires a tab-delimited key-value file for replacing the key with the value. The key-value file can be generated using the following:
 ```
@@ -106,10 +106,10 @@ positional arguments:
 optional arguments:
   -h, --help      show this help message and exit
 ```
-__Note__: Remember to add the path of the output file to the config file after running this script. 
+__Note__: Remember to add the path of the output file to the config file after running this script.
 
 ## Configuration
-Currently, `config/config-flu-only.json` has the most updated version of the configuration needed to run assembly. 
+Currently, `config/config-flu-only.json` has the most updated version of the configuration needed to run assembly.
 
 * `fastq_directory`: the path to the directory containing the fastq files
 * `ignored_samples`: an object containing keys that specify samples to be ignored
@@ -134,7 +134,7 @@ You can use `--use-conda` if there are rule-specific environment files.
 ## Basic Steps
 
 ### 1. Index reference genomes
-Using [bowtie2-build](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#the-bowtie2-build-indexer) to build a Bowtie index for each reference genome. These will later be used in the mapping step. 
+Using [bowtie2-build](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#the-bowtie2-build-indexer) to build a Bowtie index for each reference genome. These will later be used in the mapping step.
 
 ### 2. Merge lanes
 Concatenates 8 FASTQ files for each sample into 2 files (R1 and R2).
@@ -146,7 +146,7 @@ Trim raw FASTQ files with [Trimmomatic](http://www.usadellab.org/cms/?page=trimm
 Generates summary statistics using [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Allows for some quality control checks on raw sequence data coming from high throughput sequencing pipelines.
 
 ### 5. Map
-Map trimmed reads to reference genome using [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml). Outputs a BAM file that represents aligned sequences and a log file that contains the alignment summary. 
+Map trimmed reads to reference genome using [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml). Outputs a BAM file that represents aligned sequences and a log file that contains the alignment summary.
 
 ### 6. Sort
 Sort the BAM file into "genome order" using [samtools sort](http://www.htslib.org/doc/samtools.html).
@@ -155,53 +155,55 @@ Sort the BAM file into "genome order" using [samtools sort](http://www.htslib.or
 Generates statistics for coverage using [BAMStats](http://bamstats.sourceforge.net/).
 
 ### 8. Align rate checkpoint
-[Checkpoints](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) allow for data-dependent conditional execution, forcing Snakemake to re-evaluate the DAG at this point. 
+[Checkpoints](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) allow for data-dependent conditional execution, forcing Snakemake to re-evaluate the DAG at this point.
 
-Checks the alignment summary produced by the bowtie2 mapping. If the overall align rate is higher than the `min_align_rate` specified in the config, then continue with process to build consensus genome. If not, then stop the process for this sample/reference pair. 
+Checks the alignment summary produced by the bowtie2 mapping. If the overall align rate is higher than the `min_align_rate` specified in the config, then continue with process to build consensus genome. If not, then stop the process for this sample/reference pair.
 
 ### 9. Not mapped
-This rule is necessary for the checkpoint above to work, because it must send the data down one of two paths. This is the "dead end" where a consensus genome is __not__ generated. 
+This rule is necessary for the checkpoint above to work, because it must send the data down one of two paths. This is the "dead end" where a consensus genome is __not__ generated.
 
-Also a placeholder for how to handle sample/reference pairs that do not meet the `min_align_rate` threshold. Currently it just outputs the overall align rate of the sample/reference pair so that we can check that it did not meet the minimum. 
+Also a placeholder for how to handle sample/reference pairs that do not meet the `min_align_rate` threshold. Currently it just outputs the overall align rate of the sample/reference pair so that we can check that it did not meet the minimum.
 
 ### 10. Pileup
 Generates [Pileup](https://en.wikipedia.org/wiki/Pileup_format) for BAM file using [samtools mpileup](http://www.htslib.org/doc/samtools.html).
+
+  _Important Flags_:
+  * `-a` to print out all positions, including zero depth (this is necessary for generating the low coverage Bedfile later)
+  * `-A` to not discard anomalous read pairs
+  * `-Q` to set the minimum base quality to consider a read (set to match the minimum in `varscan mpileup2snp` so that their coverage depths match)
 
 ### 11. Call SNPs
 Calls SNPs from the Pileup based on parameters set in the config file using [varscan mpileup2snp](http://varscan.sourceforge.net/using-varscan.html#v2.3_mpileup2snp)
 
 ### 12. Zip VCF
-Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it. 
+Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it.
 
 ### 13. Index BCF
-Creates index for compressed VCF using [bcftools index](https://samtools.github.io/bcftools/bcftools.html#index). This index is necessary for creating the consensus genome using the compressed VCF. 
+Creates index for compressed VCF using [bcftools index](https://samtools.github.io/bcftools/bcftools.html#index). This index is necessary for creating the consensus genome using the compressed VCF.
 
 ### 14. VCF to consensus
-Create consensus genome by applying VCF variants to the reference genome using [bcftools consensus](https://samtools.github.io/bcftools/bcftools.html#consensus). This does not account for coverage, so it will just fill in blanks with the base from the reference genome. 
+Create consensus genome by applying VCF variants to the reference genome using [bcftools consensus](https://samtools.github.io/bcftools/bcftools.html#consensus). This does not account for coverage, so it will just fill in blanks with the base from the reference genome.
 
-### 15. Coverage summary
-Generates [BED](https://genome.ucsc.edu/FAQ/FAQformat.html#format1) file that reports coverage per base using [bedtools genomecov](https://bedtools.readthedocs.io/en/latest/content/tools/genomecov.html).
+### 15. Create bed file
+Creates a BED file for positions that need to be masked in the consensus genome. Positions need to be masked if they are below the minimum coverage depth and if they are disproportionally supported by one strand (>90%).
 
-### 16. Low coverage
-Searches the coverage summary BED file for bases where coverage is below the `min_cov` parameter and outputs them in a separate BED file. 
-
-### 17. Mask consensus
+### 16. Mask consensus
 Masks the consensus genome with "N" at bases where coverage is below the `min_cov` parameter using [bedtools maskfasta](https://bedtools.readthedocs.io/en/latest/content/tools/maskfasta.html).
 
-### 18. FASTA headers
-Edits the FASTA headers to fit the pattern needed for downstream analysis. 
+### 17. FASTA headers
+Edits the FASTA headers to fit the pattern needed for downstream analysis.
 Example FASTA header: `>SFS-UUID|SFS-UUID-PB2|H1N1pdm|PB2`
 1. Replace reference sequence name with the NWGC sample ID using Perl to perform "lookaround" regex matches
 2. Uses [seqkit replace](https://bioinf.shenwei.me/seqkit/usage/#replace) to replace the NWGC sample ID with the SFS UUID.
 3.  Create the UUID-gene combination using AWK
 
-### 19. Combined FASTA
-Creates the final combined FASTA file that will have all the consensus genomes generated in a day. 
+### 18. Combined FASTA
+Creates the final combined FASTA file that will have all the consensus genomes generated in a day.
 
-### 20. Aggregate
+### 19. Aggregate
 This is the last rule of the pipeline that prints out the final result of each sample/reference pair. If a consensus genome is generated, then this will also add it to the final combined FASTA.
 
-The input of this rule differs based on the result of the checkpoint, so this rule dictates the final outcome of each sample/reference pair. 
+The input of this rule differs based on the result of the checkpoint, so this rule dictates the final outcome of each sample/reference pair.
 
 ### Clean
-Deletes all of the intermediate directories and files generated from running the pipeline. The only one that it does not delete is the `consensus_genome` directory. 
+Deletes all of the intermediate directories and files generated from running the pipeline. The only one that it does not delete is the `consensus_genome` directory.

--- a/README.md
+++ b/README.md
@@ -154,10 +154,14 @@ Sort the BAM file into "genome order" using [samtools sort](http://www.htslib.or
 ### 7. Bamstats
 Generates statistics for coverage using [BAMStats](http://bamstats.sourceforge.net/).
 
-### 8. Align rate checkpoint
+### 8. Mapped reads checkpoint
 [Checkpoints](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) allow for data-dependent conditional execution, forcing Snakemake to re-evaluate the DAG at this point.
 
-Checks the alignment summary produced by the bowtie2 mapping. If the overall align rate is higher than the `min_align_rate` specified in the config, then continue with process to build consensus genome. If not, then stop the process for this sample/reference pair.
+Calculates the minimum number of reads required to meet the minimum coverage depth set for `varscan mpileup2snp` and checks the number of mapped reads from the bowtie2 alignment summary. The minimum number of reads required is calculated as:
+```
+min_reads = (reference_genome_length * min_cov) / (raw_read_length)
+```
+If `mapped_reads` is greater than or equal to `min_reads`, then continue with process to build consensus genome. If not, then stop the process for this sample/reference pair.
 
 ### 9. Not mapped
 This rule is necessary for the checkpoint above to work, because it must send the data down one of two paths. This is the "dead end" where a consensus genome is __not__ generated.

--- a/Snakefile
+++ b/Snakefile
@@ -471,7 +471,7 @@ rule fasta_headers:
             -k {input.key_value_file} --keep-key \
             temp_{wildcards.sample}.fasta > {output.masked_consensus}
         awk '{{split(substr($0,2),a,"|"); \
-            if(a[2]) print ">"a[1]"|"a[1]"-"a[3]"|"a[2]"|"a[3]; \
+            if(a[2]) print ">"a[1]"|"a[1]"-"a[2]"-"a[3]"|"a[2]"|"a[3]; \
             else print; }}' \
             {output.masked_consensus} > temp_{wildcards.sample}.fasta
         mv temp_{wildcards.sample}.fasta {output.masked_consensus}

--- a/Snakefile
+++ b/Snakefile
@@ -326,14 +326,16 @@ rule pileup:
     output:
         pileup = "process/mpileup/{reference}/{sample}.pileup"
     params:
-        depth = config["params"]["mpileup"]["depth"]
+        depth = config["params"]["mpileup"]["depth"],
+        min_base_qual = config["params"]["varscan"]["snp_qual_threshold"]
     benchmark:
         "benchmarks/{sample}_{reference}.mpileup"
     # group:
     #     "post-mapping"
     shell:
         """
-        samtools mpileup -A \
+        samtools mpileup -a -A \
+            -Q {params.min_base_qual} \
             -d {params.depth} \
             {input.sorted_bam} > {output.pileup} \
             -f {input.reference}

--- a/config/config-flu-only.json
+++ b/config/config-flu-only.json
@@ -72,10 +72,9 @@
         "mapper_filepath": "~/Downloads/sample-target-match.xlsx",
         "nwgc_column": "sample",
         "sfs_column": "uuid",
-        "key_value_filepath": "test_data/key_value.txt"  
+        "key_value_filepath": "test_data/key_value.txt"
     },
-    "min_align_rate": 
-      1.00,
+    "raw_read_length": 150,
     "reference_viruses" :
       {
         "h1n1pdm_Michigan_45_2015" : {},
@@ -111,4 +110,3 @@
           }
       }
 }
-  

--- a/scripts/checkpoint_mapped_reads.py
+++ b/scripts/checkpoint_mapped_reads.py
@@ -1,0 +1,68 @@
+"""
+Calculate minimum number of reads necessary to meet minimum depth for a
+reference and determine the number of mapped reads from bowtie2 alignment
+summary.
+
+Print both to the <output>.
+"""
+import argparse
+from Bio import SeqIO
+
+def determine_ref_genome_length(reference):
+    """
+    Calculate the genome length of a given *reference*
+    """
+    genome_length = 0
+    for segment in SeqIO.parse(reference, 'fasta'):
+        seq = segment.seq
+        seq_length = len(seq)
+        genome_length += seq_length
+    return genome_length
+
+
+def determine_number_of_mapped_reads(bowtie2):
+    """
+    Use the given *bowtie2* alignment summary to determine the total number of
+    reads that aligned with the reference
+    """
+    mapped_reads = 0
+    with open(bowtie2, "r") as summary:
+        for line in summary.readlines():
+            if "1 time" not in line:
+                continue
+            aligned = int(line.split()[0])
+            mapped_reads += aligned
+    return mapped_reads
+
+
+def print_results(minimum_reads, mapped_reads, output_file):
+    """
+    Print *minimum_reads* and *mapped_reads* in provided *output_file*
+    """
+    with open(output_file, "w") as output:
+        output.write(f"Minimum reads required: {str(minimum_reads)}\n" + \
+            f"Mapped reads: {str(mapped_reads)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--bowtie2", type=str, nargs="?", required=True,
+        help = "Summary log from bowtie2")
+    parser.add_argument("--min-cov", type=int, required=True,
+        help = "Minimum coverage set for varscan")
+    parser.add_argument("--raw-read-length", type=int, required=True,
+        help = "Length of raw reads in FASTQ files")
+    parser.add_argument("--reference", type=str, nargs="?", required=True,
+        help = "Reference FASTA file")
+    parser.add_argument("--output", type=str, nargs="?", required=True,
+        help = "The output of the checkpoint in Snakemake")
+
+    args = parser.parse_args()
+
+    genome_length = determine_ref_genome_length(args.reference)
+    minimum_reads = (genome_length * args.min_cov) / args.raw_read_length
+    mapped_reads = determine_number_of_mapped_reads(args.bowtie2)
+    print_results(minimum_reads, mapped_reads, args.output)

--- a/scripts/create_bed_file_for_masking.py
+++ b/scripts/create_bed_file_for_masking.py
@@ -1,0 +1,60 @@
+"""
+Create a bed file from the pileup file that contains all the sites where
+coverage is below a set minimum or if the site is >90% supported by one strand.
+"""
+import argparse
+import re
+
+
+def create_bed_file(pileup, min_coverage, min_freq, bed_file):
+    """
+    """
+    number_of_low_coverage = 0
+    number_of_strand_proportion = 0
+    with open(pileup, 'r') as pile:
+        with open(bed_file, 'w') as bed:
+            for line in pile:
+                line = line.split()
+                sequence = line[0]
+                end_position = line[1]
+                start_position = str(int(end_position) - 1)
+                coverage_depth = line[3]
+                variants = line[4]
+                bed_line = sequence + "\t" + start_position + "\t" + end_position + "\t"
+                if int(coverage_depth) < min_coverage:
+                    bed.write(bed_line + "coverage depth: " + coverage_depth + "\n")
+                    number_of_low_coverage += 1
+                else:
+                    total_count = len(variants)
+                    lower_count = sum(map(str.islower, variants))
+                    upper_count = sum(map(str.isupper, variants))
+                    variants_count = lower_count + upper_count
+                    max_count = max(lower_count, upper_count)
+                    if max_count == 0 or variants_count/total_count < min_freq:
+                        continue
+                    strand_proportion = max_count/variants_count
+                    if strand_proportion > 0.9:
+                        bed.write(bed_line + "strand proportion: " + str(strand_proportion) + "\n")
+                        number_of_strand_proportion += 1
+            bed.close()
+        pile.close()
+    print(f"Number of low coverage (<{min_coverage}) positions: {number_of_low_coverage}")
+    print(f"Number of off balance strand proportion (>90% one strand) positions: {number_of_strand_proportion}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--pileup", type=str, nargs="?",
+        help = "Pileup file generated from samtools mpileup")
+    parser.add_argument("--min-cov", type=int, nargs="?",
+        help = "The minimum coverage depth needed to not mask a base")
+    parser.add_argument("--min-freq", type=float, nargs="?",
+        help = "The minimum frequency of a SNP to be included.")
+    parser.add_argument("--bed-file", type=str, nargs="?",
+        help = "File path to the output bedfile")
+
+    args = parser.parse_args()
+    create_bed_file(args.pileup, args.min_cov, args.min_freq, args.bed_file)


### PR DESCRIPTION
1. Add minimum base quality to `rule pileup` so that it matches the minimum base quality in `rule call_snps`
2. The custom python script creates a bed file based on coverage and variant counts in the pileup file. If a position has coverage below the `min_cov`set in the config or if it is disproportionally supported by one strand (>90%) then it is included in the bed file. This ensures that the SNPs that fail the `--strand-filter` in `varscan mpileup2snp` is included in the bed file and are masked appropriately in the consensus genome.

This PR improves the masking process to prevent [excess mutations](https://seattle-flu-study.slack.com/archives/CFENPUAPP/p1563980844013500). 