### PR TITLE
Run one sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 Assembly pipeline used in the [Seattle Flu Study](https://seattleflu.org/) to build consensus genomes for sequenced samples.
 
-Adapted from Louise Moncla's [Illumina pipline](https://github.com/lmoncla/illumina_pipeline) for influenza snp calling. 
+Adapted from Louise Moncla's [Illumina pipline](https://github.com/lmoncla/illumina_pipeline) for influenza snp calling.
 
 ## Installation
 Install dependencies via Conda by running:
@@ -44,7 +44,7 @@ optional arguments:
   -h, --help       show this help message and exit
 ```
 ### Setup Config File
-By default, the pipeline will generate combinations of all samples and references and try to create consensus genomes for all combinations.  
+By default, the pipeline will generate combinations of all samples and references and try to create consensus genomes for all combinations.
 
 Avoid this by specifying specific sample-reference pairs and ignored samples in the config file by using:
 ```
@@ -81,10 +81,10 @@ optional arguments:
 __Note__: This currently only works for flu-positive samples. To add more targets/references, edit `references/target_reference_map.json`.
 
 #### Check Read Pairs
-Embedded in this script is a check to ensure that the reads in R1 and R2 of each sample match. This is to avoid the demultiplexing error described in [this paper](https://www.nature.com/articles/s41588-019-0349-3). If the reads differ by over 20% then the sample will be added to the ignored samples. Redirect the output to a file to keep track of read differences and ignored samples. 
+Embedded in this script is a check to ensure that the reads in R1 and R2 of each sample match. This is to avoid the demultiplexing error described in [this paper](https://www.nature.com/articles/s41588-019-0349-3). If the reads differ by over 20% then the sample will be added to the ignored samples. Redirect the output to a file to keep track of read differences and ignored samples.
 
 ### NWGC ID/SFS UUID key-value pair
-Consensus genome FASTA headers are generated with the NWGC sample ID which then needs to be converted to the SFS UUID in order to be paired with stored metadata. 
+Consensus genome FASTA headers are generated with the NWGC sample ID which then needs to be converted to the SFS UUID in order to be paired with stored metadata.
 
 This is done with the [seqkit replace](https://bioinf.shenwei.me/seqkit/usage/#replace) method, which requires a tab-delimited key-value file for replacing the key with the value. The key-value file can be generated using the following:
 ```
@@ -106,10 +106,10 @@ positional arguments:
 optional arguments:
   -h, --help      show this help message and exit
 ```
-__Note__: Remember to add the path of the output file to the config file after running this script. 
+__Note__: Remember to add the path of the output file to the config file after running this script.
 
 ## Configuration
-Currently, `config/config-flu-only.json` has the most updated version of the configuration needed to run assembly. 
+Currently, `config/config-flu-only.json` has the most updated version of the configuration needed to run assembly.
 
 * `fastq_directory`: the path to the directory containing the fastq files
 * `ignored_samples`: an object containing keys that specify samples to be ignored
@@ -134,7 +134,7 @@ You can use `--use-conda` if there are rule-specific environment files.
 ## Basic Steps
 
 ### 1. Index reference genomes
-Using [bowtie2-build](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#the-bowtie2-build-indexer) to build a Bowtie index for each reference genome. These will later be used in the mapping step. 
+Using [bowtie2-build](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#the-bowtie2-build-indexer) to build a Bowtie index for each reference genome. These will later be used in the mapping step.
 
 ### 2. Merge lanes
 Concatenates 8 FASTQ files for each sample into 2 files (R1 and R2).
@@ -146,7 +146,7 @@ Trim raw FASTQ files with [Trimmomatic](http://www.usadellab.org/cms/?page=trimm
 Generates summary statistics using [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Allows for some quality control checks on raw sequence data coming from high throughput sequencing pipelines.
 
 ### 5. Map
-Map trimmed reads to reference genome using [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml). Outputs a BAM file that represents aligned sequences and a log file that contains the alignment summary. 
+Map trimmed reads to reference genome using [bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml). Outputs a BAM file that represents aligned sequences and a log file that contains the alignment summary.
 
 ### 6. Sort
 Sort the BAM file into "genome order" using [samtools sort](http://www.htslib.org/doc/samtools.html).
@@ -155,14 +155,14 @@ Sort the BAM file into "genome order" using [samtools sort](http://www.htslib.or
 Generates statistics for coverage using [BAMStats](http://bamstats.sourceforge.net/).
 
 ### 8. Align rate checkpoint
-[Checkpoints](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) allow for data-dependent conditional execution, forcing Snakemake to re-evaluate the DAG at this point. 
+[Checkpoints](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) allow for data-dependent conditional execution, forcing Snakemake to re-evaluate the DAG at this point.
 
-Checks the alignment summary produced by the bowtie2 mapping. If the overall align rate is higher than the `min_align_rate` specified in the config, then continue with process to build consensus genome. If not, then stop the process for this sample/reference pair. 
+Checks the alignment summary produced by the bowtie2 mapping. If the overall align rate is higher than the `min_align_rate` specified in the config, then continue with process to build consensus genome. If not, then stop the process for this sample/reference pair.
 
 ### 9. Not mapped
-This rule is necessary for the checkpoint above to work, because it must send the data down one of two paths. This is the "dead end" where a consensus genome is __not__ generated. 
+This rule is necessary for the checkpoint above to work, because it must send the data down one of two paths. This is the "dead end" where a consensus genome is __not__ generated.
 
-Also a placeholder for how to handle sample/reference pairs that do not meet the `min_align_rate` threshold. Currently it just outputs the overall align rate of the sample/reference pair so that we can check that it did not meet the minimum. 
+Also a placeholder for how to handle sample/reference pairs that do not meet the `min_align_rate` threshold. Currently it just outputs the overall align rate of the sample/reference pair so that we can check that it did not meet the minimum.
 
 ### 10. Pileup
 Generates [Pileup](https://en.wikipedia.org/wiki/Pileup_format) for BAM file using [samtools mpileup](http://www.htslib.org/doc/samtools.html).
@@ -176,13 +176,13 @@ Generates [Pileup](https://en.wikipedia.org/wiki/Pileup_format) for BAM file usi
 Calls SNPs from the Pileup based on parameters set in the config file using [varscan mpileup2snp](http://varscan.sourceforge.net/using-varscan.html#v2.3_mpileup2snp)
 
 ### 12. Zip VCF
-Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it. 
+Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it.
 
 ### 13. Index BCF
-Creates index for compressed VCF using [bcftools index](https://samtools.github.io/bcftools/bcftools.html#index). This index is necessary for creating the consensus genome using the compressed VCF. 
+Creates index for compressed VCF using [bcftools index](https://samtools.github.io/bcftools/bcftools.html#index). This index is necessary for creating the consensus genome using the compressed VCF.
 
 ### 14. VCF to consensus
-Create consensus genome by applying VCF variants to the reference genome using [bcftools consensus](https://samtools.github.io/bcftools/bcftools.html#consensus). This does not account for coverage, so it will just fill in blanks with the base from the reference genome. 
+Create consensus genome by applying VCF variants to the reference genome using [bcftools consensus](https://samtools.github.io/bcftools/bcftools.html#consensus). This does not account for coverage, so it will just fill in blanks with the base from the reference genome.
 
 ### 15. Create bed file
 Creates a BED file for positions that need to be masked in the consensus genome. Positions need to be masked if they are below the minimum coverage depth and if they are disproportionally supported by one strand (>90%).
@@ -203,7 +203,7 @@ Creates the final combined FASTA file that will have all the consensus genomes g
 ### 19. Aggregate
 This is the last rule of the pipeline that prints out the final result of each sample/reference pair. If a consensus genome is generated, then this will also add it to the final combined FASTA.
 
-The input of this rule differs based on the result of the checkpoint, so this rule dictates the final outcome of each sample/reference pair. 
+The input of this rule differs based on the result of the checkpoint, so this rule dictates the final outcome of each sample/reference pair.
 
 ### Clean
-Deletes all of the intermediate directories and files generated from running the pipeline. The only one that it does not delete is the `consensus_genome` directory. 
+Deletes all of the intermediate directories and files generated from running the pipeline. The only one that it does not delete is the `consensus_genome` directory.

--- a/Snakefile
+++ b/Snakefile
@@ -437,7 +437,7 @@ rule nwgc_sfs_map:
         key_value_file = config["barcode_match"]["key_value_filepath"]
     shell:
         """
-        python3 scripts/id_barcode_key_value.py \
+        python scripts/id_barcode_key_value.py \
             {params.mapper_file} \
             {params.nwgc_column} \
             {params.sfs_column} \

--- a/Snakefile
+++ b/Snakefile
@@ -98,7 +98,7 @@ def aggregate_input(wildcards):
         if float(f.read().strip()[:3]) < config["min_align_rate"]:
             return "summary/not_mapped/{reference}/{sample}.txt"
         else:
-            return "consensus_genomes/{reference}/{sample}.masked_consensus.fasta"
+            return "consensus_genomes/{reference}/{sample}.http-response.log"
 
 # Build static lists of reference genomes, ID's of samples, and ID -> input files
 all_references = [ v for v in  config['reference_viruses'].keys() ]
@@ -121,9 +121,6 @@ rule all:
         aggregate = expand("summary/aggregate/{reference}/{sample}.log", filtered_product,
                 sample=all_ids,
                 reference=all_references),
-        log = expand("consensus_genomes/{reference}/{sample}.http-response.log", filtered_product,
-                sample=all_ids,
-                reference=all_references)
 
 rule index_reference_genome:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -304,7 +304,7 @@ checkpoint align_rate:
     input:
         bt2_log = rules.map.output.bt2_log
     output:
-        temp("summary/align_rate/{reference}/{sample}.txt")
+        align_rate = "summary/align_rate/{reference}/{sample}.txt"
     shell:
         """
         tail -n 1 {input}  > {output}

--- a/Snakefile
+++ b/Snakefile
@@ -326,14 +326,16 @@ rule pileup:
     output:
         pileup = "process/mpileup/{reference}/{sample}.pileup"
     params:
-        depth = config["params"]["mpileup"]["depth"]
+        depth = config["params"]["mpileup"]["depth"],
+        min_base_qual = config["params"]["varscan"]["snp_qual_threshold"]
     benchmark:
         "benchmarks/{sample}_{reference}.mpileup"
     # group:
     #     "post-mapping"
     shell:
         """
-        samtools mpileup -A \
+        samtools mpileup -a -A \
+            -Q {params.min_base_qual} \
             -d {params.depth} \
             {input.sorted_bam} > {output.pileup} \
             -f {input.reference}

--- a/Snakefile
+++ b/Snakefile
@@ -307,7 +307,7 @@ checkpoint align_rate:
         """
 
 rule not_mapped:
-    input: 
+    input:
         sorted_bam = rules.sort.output.sorted_bam_file,
         reference = "references/{reference}.fasta",
         temp = "summary/align_rate/{reference}/{sample}.txt"
@@ -473,13 +473,13 @@ rule combined_fasta:
         """
         touch {output.combined_fasta}
         """
-    
+
 rule aggregate:
     input:
         aggregate_input = aggregate_input
     output:
         aggregate_summary = "summary/aggregate/{reference}/{sample}.log"
-    params: 
+    params:
         combined_fasta = rules.combined_fasta.output
     run:
         if input.aggregate_input.split(".")[-1] == "fasta":
@@ -488,7 +488,7 @@ rule aggregate:
 
 rule clean:
     message: "Removing directories: {params}"
-    params: 
+    params:
         "summary "
         "process "
         "benchmarks "

--- a/Snakefile_one_sample
+++ b/Snakefile_one_sample
@@ -1,0 +1,484 @@
+"""Snakefile for one sample/target pair
+
+Processes input fastq files to create consensus genomes and their associated
+summary statistics for the Seattle Flu Study.
+
+Install and activate the appropriate environment for the pipeline using
+Conda (https://conda.io/en/latest/):
+    $ conda env create -f envs/seattle-flu-environment.yaml
+    $ conda activate seattle-flu
+
+Before running perform a dry-run to test that all input files are correctly
+located and that the Snakemake DAG builds correctly:
+    $ snakemake -n
+
+To run on a local machine:
+    $ snakemake -k
+
+To run on the Fred Hutch cluster (Rhino):
+    $ snakemake \
+        -w 60 \
+        --cluster-config config/cluster.json \
+        --cluster "sbatch \
+            --nodes=1 \
+            --tasks=1 \
+            --mem={cluster.memory} \
+            --cpus-per-task={cluster.cores} \
+            --tmp={cluster.disk} \
+            --time={cluster.time} \
+            -o all_output.out" \
+        -j 20 \
+        -k
+
+Basic steps:
+    1. Trim raw fastq's with Trimmomatic
+    2. Map trimmed reads to each reference genomes in the reference panel using
+       bowtie2 # This step may change with time
+    ~3. Remove duplicate reads using Picard~
+    4. Call SNPs using varscan
+    5. Use SNPs to generate full consensus genomes for each sample x reference
+       virus combination
+    6. Compute summary statistics for each sample x refernce virus combination
+
+Adapted from Louise Moncla's illumina pipeline for influenza snp calling:
+https://github.com/lmoncla/illumina_pipeline
+"""
+import getpass
+from datetime import datetime
+
+
+# input function for the rule aggregate
+def aggregate_input(wildcards):
+    """
+    Returns input for rule aggregate based on output from checkpoint align_rate.
+    Set minimum align rate in config under "min_align_rate".
+    """
+    with open(checkpoints.align_rate.get(sample=wildcards.sample, reference=wildcards.reference, date=wildcards.date).output[0]) as f:
+        if float(f.read().strip()[:3]) < config["min_align_rate"]:
+            return "{date}/summary/not_mapped/{reference}/{sample}.txt"
+        else:
+            return "{date}/consensus_genomes/{reference}/{sample}.http-response.log"
+
+sample = config["sample"]
+references = config["references"]
+date=datetime.now().date()
+
+#### Main pipeline
+rule all:
+    input:
+        # pre_fastqc = expand("summary/pre_trim_fastqc/{fname}_fastqc.html",
+        #        fname=glob.glob(config['fastq_directory']),
+        post_fastqc = expand("{date}/summary/post_trim_fastqc/{sample}.trimmed_{tr}_fastqc.{ext}",
+               date=date,
+               sample=sample,
+               tr=["1P", "1U", "2P", "2U"],
+               ext=["zip", "html"]),
+        bamstats = expand("{date}/summary/bamstats/{reference}/{sample}.coverage_stats.txt",
+               date=date,
+               sample=sample,
+               reference=references),
+        aggregate = expand("{date}/summary/aggregate/{reference}/{sample}.log",
+                date=date,
+                sample=sample,
+                reference=references)
+
+rule index_reference_genome:
+    input:
+        raw_reference = "references/{reference}.fasta"
+    output:
+        indexed_reference = "references/{reference}.1.bt2"
+    # group:
+    #     "pre-mapping"
+    shell:
+        """
+        bowtie2-build {input.raw_reference} references/{wildcards.reference}
+        """
+
+rule merge_lanes:
+    input:
+        all_r1 = config["fastq_files"]["R1"],
+        all_r2 = config["fastq_files"]["R2"]
+    output:
+        merged_r1 = "{date}/process/merged/{sample}_R1.fastq.gz",
+        merged_r2 = "{date}/process/merged/{sample}_R2.fastq.gz"
+    # group:
+    #     "pre-mapping"
+    shell:
+        """
+        cat {input.all_r1} >> {output.merged_r1}
+        cat {input.all_r2} >> {output.merged_r2}
+        """
+
+rule trim_fastqs:
+    input:
+        fastq_f = "{date}/process/merged/{sample}_R1.fastq.gz",
+        fastq_r = "{date}/process/merged/{sample}_R2.fastq.gz"
+    output:
+        trimmed_fastq_1p = "{date}/process/trimmed/{sample}.trimmed_1P.fastq",
+        trimmed_fastq_2p = "{date}/process/trimmed/{sample}.trimmed_2P.fastq",
+        trimmed_fastq_1u = "{date}/process/trimmed/{sample}.trimmed_1U.fastq",
+        trimmed_fastq_2u = "{date}/process/trimmed/{sample}.trimmed_2U.fastq"
+    params:
+        paired_end = config["params"]["trimmomatic"]["paired_end"],
+        adapters = config["params"]["trimmomatic"]["adapters"],
+        illumina_clip = config["params"]["trimmomatic"]["illumina_clip"],
+        window_size = config["params"]["trimmomatic"]["window_size"],
+        trim_qscore = config["params"]["trimmomatic"]["trim_qscore"],
+        minimum_length = config["params"]["trimmomatic"]["minimum_length"]
+    benchmark:
+        "{date}/benchmarks/{sample}.trimmo"
+    # group:
+    #     "trim-and-map"
+    shell:
+        """
+        trimmomatic \
+            {params.paired_end} \
+            -phred33 \
+            {input.fastq_f} {input.fastq_r} \
+            -baseout {wildcards.date}/process/trimmed/{wildcards.sample}.trimmed.fastq \
+            ILLUMINACLIP:{params.adapters}:{params.illumina_clip} \
+            SLIDINGWINDOW:{params.window_size}:{params.trim_qscore} \
+            MINLEN:{params.minimum_length}
+        """
+
+rule post_trim_fastqc:
+    input:
+        p1 = rules.trim_fastqs.output.trimmed_fastq_1p,
+        p2 = rules.trim_fastqs.output.trimmed_fastq_2p,
+        u1 = rules.trim_fastqs.output.trimmed_fastq_1u,
+        u2 = rules.trim_fastqs.output.trimmed_fastq_2u
+    output:
+        qc_1p_html = "{date}/summary/post_trim_fastqc/{sample}.trimmed_1P_fastqc.html",
+        qc_2p_html = "{date}/summary/post_trim_fastqc/{sample}.trimmed_2P_fastqc.html",
+        qc_1u_html = "{date}/summary/post_trim_fastqc/{sample}.trimmed_1U_fastqc.html",
+        qc_2u_html = "{date}/summary/post_trim_fastqc/{sample}.trimmed_2U_fastqc.html",
+        qc_1p_zip = "{date}/summary/post_trim_fastqc/{sample}.trimmed_1P_fastqc.zip",
+        qc_2p_zip = "{date}/summary/post_trim_fastqc/{sample}.trimmed_2P_fastqc.zip",
+        qc_1u_zip = "{date}/summary/post_trim_fastqc/{sample}.trimmed_1U_fastqc.zip",
+        qc_2u_zip = "{date}/summary/post_trim_fastqc/{sample}.trimmed_2U_fastqc.zip"
+    # group:
+    #     "summary-statistics"
+    shell:
+        """
+        fastqc {input.p1} -o {wildcards.date}/summary/post_trim_fastqc
+        fastqc {input.p2} -o {wildcards.date}/summary/post_trim_fastqc
+        fastqc {input.u1} -o {wildcards.date}/summary/post_trim_fastqc
+        fastqc {input.u2} -o {wildcards.date}/summary/post_trim_fastqc
+        """
+
+rule map:
+    input:
+        p1 = rules.trim_fastqs.output.trimmed_fastq_1p,
+        p2 = rules.trim_fastqs.output.trimmed_fastq_2p,
+        u1 = rules.trim_fastqs.output.trimmed_fastq_1u,
+        u2 = rules.trim_fastqs.output.trimmed_fastq_2u,
+        ref_file = rules.index_reference_genome.output.indexed_reference
+    output:
+        mapped_bam_file = "{date}/process/mapped/{reference}/{sample}.bam",
+        bt2_log = "{date}/summary/bowtie2/{reference}/{sample}.log"
+    params:
+        threads = config["params"]["bowtie2"]["threads"],
+        map_all = config["params"]["bowtie2"]["all"]
+    benchmark:
+        "{date}/benchmarks/{sample}_{reference}.bowtie2"
+    # group:
+    #     "trim-and-map"
+    shell:
+        """
+        bowtie2 \
+            -x references/{wildcards.reference} \
+            -1 {input.p1} \
+            -2 {input.p2} \
+            -U {input.u1},{input.u2} \
+            -P {params.threads} \
+            {params.map_all} \
+            --local 2> {output.bt2_log} | \
+                samtools view -bSF4 - > {output.mapped_bam_file}
+        """
+
+rule sort:
+    input:
+        mapped_bam = rules.map.output.mapped_bam_file
+    output:
+        sorted_bam_file = "{date}/process/sorted/{reference}/{sample}.sorted.bam"
+    benchmark:
+        "{date}/benchmarks/{sample}_{reference}.sort"
+    # group:
+    #     "post-mapping"
+    shell:
+        """
+        samtools view \
+            -bS {input.mapped_bam} | \
+            samtools sort | \
+            samtools view -h > {output.sorted_bam_file}
+        """
+
+rule bamstats:
+    input:
+        sorted_bam = rules.sort.output.sorted_bam_file
+    output:
+        bamstats_file = "{date}/summary/bamstats/{reference}/{sample}.coverage_stats.txt"
+    benchmark:
+        "{date}/benchmarks/{sample}_{reference}.bamstats"
+    # group:
+    #     "summary-statistics"
+    shell:
+        """
+        BAMStats -i {input.sorted_bam} > {output.bamstats_file}
+        """
+
+checkpoint align_rate:
+    input:
+        bt2_log = rules.map.output.bt2_log
+    output:
+        align_rate = "{date}/summary/align_rate/{reference}/{sample}.txt"
+    shell:
+        """
+        tail -n 1 {input}  > {output}
+        """
+
+rule not_mapped:
+    input:
+        sorted_bam = rules.sort.output.sorted_bam_file,
+        reference = "references/{reference}.fasta",
+        temp = "{date}/summary/align_rate/{reference}/{sample}.txt"
+    output:
+        not_mapped = "{date}/summary/not_mapped/{reference}/{sample}.txt"
+    shell:
+        """
+        cat {input.temp} > {output.not_mapped}
+        """
+
+rule pileup:
+    input:
+        sorted_bam = rules.sort.output.sorted_bam_file,
+        reference = "references/{reference}.fasta",
+        temp = "{date}/summary/align_rate/{reference}/{sample}.txt"
+    output:
+        pileup = "{date}/process/mpileup/{reference}/{sample}.pileup"
+    params:
+        depth = config["params"]["mpileup"]["depth"],
+        min_base_qual = config["params"]["varscan"]["snp_qual_threshold"]
+    benchmark:
+        "{date}/benchmarks/{sample}_{reference}.mpileup"
+    # group:
+    #     "post-mapping"
+    shell:
+        """
+        samtools mpileup -a -A \
+            -Q {params.min_base_qual} \
+            -d {params.depth} \
+            {input.sorted_bam} > {output.pileup} \
+            -f {input.reference}
+        """
+
+rule call_snps:
+    input:
+        pileup = rules.pileup.output.pileup
+    output:
+        vcf = "{date}/process/vcfs/{reference}/{sample}.vcf"
+    params:
+        min_cov = config["params"]["varscan"]["min_cov"],
+        snp_qual_threshold = config["params"]["varscan"]["snp_qual_threshold"],
+        snp_frequency = config["params"]["varscan"]["snp_frequency"]
+    benchmark:
+        "{date}/benchmarks/{sample}_{reference}.varscan"
+    shell:
+        """
+        varscan mpileup2snp \
+            {input.pileup} \
+            --min-coverage {params.min_cov} \
+            --min-avg-qual {params.snp_qual_threshold} \
+            --min-var-freq {params.snp_frequency} \
+            --strand-filter 1 \
+            --output-vcf 1 > {output.vcf}
+        """
+
+rule zip_vcf:
+    input:
+        vcf = rules.call_snps.output.vcf
+    output:
+        bcf = "{date}/process/vcfs/{reference}/{sample}.vcf.gz"
+    shell:
+        """
+        bgzip {input.vcf}
+        """
+
+rule index_bcf:
+    input:
+        bcf = rules.zip_vcf.output.bcf
+    output:
+        index = "{date}/process/vcfs/{reference}/{sample}.vcf.gz.csi"
+    shell:
+        """
+        bcftools index {input}
+        """
+
+rule vcf_to_consensus:
+    input:
+        bcf = rules.zip_vcf.output.bcf,
+        index = rules.index_bcf.output.index,
+        ref = "references/{reference}.fasta"
+    output:
+        consensus_genome = "{date}/consensus_genomes/{reference}/{sample}.consensus.fasta"
+    benchmark:
+        "{date}/benchmarks/{sample}_{reference}.consensus"
+    shell:
+        """
+        cat {input.ref} | \
+            bcftools consensus {input.bcf} > \
+            {output.consensus_genome}
+        """
+
+rule create_bed_file:
+    input:
+        pileup = rules.pileup.output.pileup
+    output:
+        bed_file = "{date}/summary/low_coverage/{reference}/{sample}.bed"
+    params:
+        min_cov = config["params"]["varscan"]["min_cov"]
+    shell:
+        """
+        python scripts/create_bed_file_for_masking.py \
+            --pileup {input.pileup} \
+            --min-cov {params.min_cov} \
+            --bed-file {output.bed_file}
+        """
+
+rule mask_consensus:
+    input:
+        consensus_genome = rules.vcf_to_consensus.output.consensus_genome,
+        low_coverage = rules.create_bed_file.output.bed_file
+    output:
+        masked_consensus = temp("{date}/consensus_genomes/{reference}/{sample}.temp_consensus.fasta")
+    shell:
+        """
+        bedtools maskfasta \
+            -fi {input.consensus_genome} \
+            -bed {input.low_coverage} \
+            -fo {output.masked_consensus}
+        """
+
+rule fasta_headers:
+    input:
+        key_value_file = config["barcode_match"],
+        masked_consensus = rules.mask_consensus.output
+    output:
+        masked_consensus = "{date}/consensus_genomes/{reference}/{sample}.masked_consensus.fasta"
+    shell:
+        """
+        cat {input.masked_consensus} | \
+            perl -pi -e 's/(?<=>)[^>|]*(?<=|)/{wildcards.sample}/g' > \
+            temp_{wildcards.sample}.fasta
+        seqkit replace -p '({wildcards.sample})' -r '{{kv}}' \
+            -k {input.key_value_file} --keep-key \
+            temp_{wildcards.sample}.fasta > {output.masked_consensus}
+        awk '{{split(substr($0,2),a,"|"); \
+            if(a[2]) print ">"a[1]"|"a[1]"-"a[3]"|"a[2]"|"a[3]; \
+            else print; }}' \
+            {output.masked_consensus} > temp_{wildcards.sample}.fasta
+        mv temp_{wildcards.sample}.fasta {output.masked_consensus}
+
+        """
+
+rule metadata_to_json:
+    input:
+        all_r1 = config["fastq_files"]["R1"],
+        all_r2 = config["fastq_files"]["R2"]
+    output:
+        temp("{date}/consensus_genomes/{reference}/{sample}.metadata.json")
+    shell:
+        """
+        python scripts/metadata_to_json.py "{input.all_r1}" "{input.all_r2}" > {output}
+        """
+
+rule masked_consensus_to_json:
+    input:
+        masked_consensus = rules.fasta_headers.output.masked_consensus
+    output:
+        temp("{date}/consensus_genomes/{reference}/{sample}.masked_consensus.json")
+    shell:
+        """
+        python scripts/fasta_to_json.py {input.masked_consensus} > {output}
+        """
+
+rule summary_stats_to_json:
+    input:
+        bam_coverage = rules.bamstats.output.bamstats_file,
+        bowtie2 = rules.map.output.bt2_log
+    output:
+        temp("{date}/consensus_genomes/{reference}/{sample}.summary_stats.json")
+    shell:
+        """
+        python scripts/summary_stats_to_json.py --bamstats {input.bam_coverage} \
+            --bowtie2 {input.bowtie2} > {output}
+        """
+
+checkpoint create_id3c_payload:
+    input:
+        metadata = rules.metadata_to_json.output,
+        masked_consensus = rules.masked_consensus_to_json.output,
+        summary_stats = rules.summary_stats_to_json.output
+    output:
+        "{date}/consensus_genomes/{reference}/{sample}.payload.json"
+    shell:
+        """
+        python scripts/create_id3c_payload.py \
+            --masked-consensus {input.masked_consensus} \
+            --summary-stats {input.summary_stats} \
+            --metadata {input.metadata} > {output}
+        """
+
+rule post_masked_consensus_and_summary_stats_to_id3c:
+    input:
+        rules.create_id3c_payload.output
+    params:
+        id3c_url = config['id3c-consensus-genome-post-url'],
+        id3c_username_and_password = config['id3c-username-and-password'],
+        id3c_expected_response_code = 204,
+        id3c_slack_webhook = config['id3c-alerts-slack-webhook'],
+        user = getpass.getuser()
+    log: "{date}/consensus_genomes/{reference}/{sample}.http-response.log"
+    shell:
+        """
+        response=$(curl {params.id3c_url} \
+            --header "Content-Type: application/json" \
+            --data-binary @{input} \
+            --user {params.id3c_username_and_password} \
+            --write-out "%{{http_code}}\n" \
+            --output {log})
+        if [ "$response" != "{params.id3c_expected_response_code}" ]
+        then
+            echo "Something went wrong in the ID3C POST request.\nSee {log} for more information."
+            curl -X POST -H 'Content-type: application/json' \
+                --data '{{"text": \
+                ":rotating_light: @{params.user} Assembly failed to upload to ID3C.\nMore details at `{log}`"}}' \
+                {params.id3c_slack_webhook}
+
+            exit $response
+        fi
+        """
+
+
+rule aggregate:
+    input:
+        aggregate_input = aggregate_input
+    output:
+        aggregate_summary = "{date}/summary/aggregate/{reference}/{sample}.log"
+    shell:
+        """
+        echo 'Final output: {input.aggregate_input}' > {output}
+        """
+
+rule clean:
+    message: "Removing directories: {params}"
+    params:
+        "*/summary "
+        "*/process "
+        "*/benchmarks "
+        "references/*.bt2 "
+        "references/*.fai"
+    shell:
+        """
+        rm -rfv {params}
+        """

--- a/config/config-flu-only.json
+++ b/config/config-flu-only.json
@@ -85,6 +85,7 @@
       },
     "id3c-consensus-genome-post-url": "http://localhost:5000/v1/receiving/consensus-genome",
     "id3c-username-and-password": "test:123",
+    "id3c-alerts-slack-webhook": "ID3C-ALERTS-SLACK-WEBHOOK-URL",
     "params" :
       {
         "trimmomatic" :

--- a/config/config-flu-only.json
+++ b/config/config-flu-only.json
@@ -83,6 +83,8 @@
         "h3n2_Texas_50_2012": {},
         "yam_Wisconsin_01_2010": {}
       },
+    "id3c-consensus-genome-post-url": "http://localhost:5000/v1/receiving/consensus-genome",
+    "id3c-username-and-password": "test:123",
     "params" :
       {
         "trimmomatic" :

--- a/config/one-sample-template.json
+++ b/config/one-sample-template.json
@@ -1,0 +1,39 @@
+{
+    "fastq_files" : [],
+    "sample": "",
+    "references": [],
+    "barcode_match" :
+      "test_data/key_value.txt",
+    "min_align_rate":
+      1.00,
+    "id3c-consensus-genome-post-url": "http://localhost:5000/v1/receiving/consensus-genome",
+    "id3c-username-and-password": "test:123",
+    "id3c-alerts-slack-webhook": "ID3C-ALERTS-SLACK-WEBHOOK-URL",
+    "params" :
+      {
+        "trimmomatic" :
+          {
+            "paired_end" : "PE",
+            "adapters" : "illumina-adapters.fasta",
+            "illumina_clip" : "1:30:10",
+            "window_size" : "5",
+            "trim_qscore" : "30",
+            "minimum_length" : "50"
+          },
+        "bowtie2" :
+          {
+            "threads" : "4",
+            "all" : "-a"
+          },
+        "mpileup" :
+          {
+            "depth" : "1000000"
+          },
+        "varscan" :
+          {
+            "min_cov" : "20",
+            "snp_qual_threshold" : "30",
+            "snp_frequency" : "0.50"
+          }
+      }
+}

--- a/scripts/create_bed_file_for_masking.py
+++ b/scripts/create_bed_file_for_masking.py
@@ -1,0 +1,58 @@
+"""
+Create a bed file from the pileup file that contains all the sites where
+coverage is below a set minimum or if the site is >90% supported by one strand.
+"""
+import argparse
+import re
+
+
+def create_bed_file(pileup, min_coverage, bed_file):
+    """
+    """
+    number_of_low_coverage = 0
+    number_of_strand_proportion = 0
+    with open(pileup, 'r') as pile:
+        with open(bed_file, 'w') as bed:
+            for line in pile:
+                line = line.split()
+                sequence = line[0]
+                end_position = line[1]
+                start_position = str(int(end_position) - 1)
+                coverage_depth = line[3]
+                variants = line[4]
+                bed_line = sequence + "\t" + start_position + "\t" + end_position + "\t"
+                if int(coverage_depth) < min_coverage:
+                    bed.write(bed_line + "coverage depth: " + coverage_depth + "\n")
+                    number_of_low_coverage += 1
+                else:
+                    total_count = len(variants)
+                    lower_count = sum(map(str.islower, variants))
+                    upper_count = sum(map(str.isupper, variants))
+                    variants_count = lower_count + upper_count
+                    max_count = max(lower_count, upper_count)
+                    if max_count == 0 or variants_count/total_count < 0.5:
+                        continue
+                    strand_proportion = max_count/variants_count
+                    if strand_proportion > 0.9:
+                        bed.write(bed_line + "strand proportion: " + str(strand_proportion) + "\n")
+                        number_of_strand_proportion += 1
+            bed.close()
+        pile.close()
+    print(f"Number of low coverage (<{min_coverage}) positions: {number_of_low_coverage}")
+    print(f"Number of off balance strand proportion (>90% one strand) positions: {number_of_strand_proportion}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--pileup", type=str, nargs="?",
+        help = "Pileup file generated from samtools mpileup")
+    parser.add_argument("--min-cov", type=int, nargs="?",
+        help = "The minimum coverage depth needed to not mask a base")
+    parser.add_argument("--bed-file", type=str, nargs="?",
+        help = "File path to the output bedfile")
+
+    args = parser.parse_args()
+    create_bed_file(args.pileup, args.min_cov, args.bed_file)

--- a/scripts/create_id3c_payload.py
+++ b/scripts/create_id3c_payload.py
@@ -1,0 +1,64 @@
+"""
+Combine the masked consensus Json fasta file and the bamstats/bowtie2 summary
+stats Json file into one Json for upload to ID3C.
+"""
+import re
+import json
+import argparse
+
+def check_sample_ids(masked_consensus: str, summary_stats: str) -> None:
+    """"""
+    regex = '.*/([0-9]{6,}).*.json'
+    match = re.search(regex, summary_stats)
+    sample_id = match.group(1)
+
+    assert re.search(regex, masked_consensus).group(1), \
+        "The NWGC sample IDs for the given files do not match."
+
+
+def check_organism_ids(masked_consensus: dict, summary_stats: dict) -> None:
+    """"""
+    assert masked_consensus['reference_organism'].lower() == \
+        summary_stats['reference_organism'].lower(), \
+        "The reference organisms for the given files do not match!"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__ ,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--masked-consensus", type=str,
+        help="The masked consensus Json file, output of `rule masked_consensus_to_json`",
+        required=True)
+    parser.add_argument("--summary-stats", type=str,
+        help="The summary stats Json file, output of `rule summary_stats_to_json`",
+        required=True)
+    parser.add_argument("--metadata", type=str,
+        help="The metadata Json file, output of `rule metadata_to_json`",
+        required=True)
+    parser.add_argument("--status", type=str,
+        choices=['complete', 'failed', 'notMapped'],
+        help="The mapping status of the consensus genome.",
+        required=True)
+
+    args = parser.parse_args()
+    check_sample_ids(args.masked_consensus, args.summary_stats)
+
+    with open(args.summary_stats) as f:
+        summary_stats = json.load(f)
+
+    with open(args.masked_consensus) as f:
+        masked_consensus = json.load(f)
+
+    with open(args.metadata) as f:
+        metadata = json.load(f)
+
+    status = { 'status': args.status }
+    check_organism_ids(masked_consensus, summary_stats)
+
+    print(json.dumps({
+        **status,
+        **masked_consensus,
+        **summary_stats,
+        **metadata }, indent=4))

--- a/scripts/fasta_to_json.py
+++ b/scripts/fasta_to_json.py
@@ -1,0 +1,70 @@
+"""
+Converts a fasta file input to machine-readable, Json format. The Json document
+is printed to stdout, so the user will likely want to redirect this to a new
+file.
+"""
+import re
+import json
+import argparse
+from Bio import SeqIO
+
+
+def fasta_to_json(fasta_file):
+    consensus_genomes = list(SeqIO.parse(fasta_file, "fasta"))
+
+    organism = None
+    sample_identifier = None
+    converted_genomes = []
+
+    for segment in consensus_genomes:
+        header = segment.id.split("|")
+
+        sample_identifier = check_sample_identifier(header, sample_identifier)
+        sequence_identifier = header[1]
+        organism = check_organism(header, organism)
+        sequence_segment = header[3]
+
+        sequence = str(segment.seq)
+
+        genome_data = {
+            "sequence_identifier": sequence_identifier,
+            "sequence_segment": sequence_segment,
+            "genomic_sequence": sequence
+        }
+        converted_genomes.append(genome_data)
+
+    print(json.dumps(
+        {
+            'sample_identifier': sample_identifier,
+            'reference_organism': organism,
+            'masked_consensus': converted_genomes
+        }, indent=4))
+
+
+def check_sample_identifier(header: str, sample_id: str) -> str:
+    """"""
+    if sample_id and header[0] != sample_id:
+        raise AssertionError("There are multiple sample identifiers in the given fasta file.")
+
+    return header[0]
+
+
+def check_organism(header: str, organism_id: str) -> str:
+    """"""
+    if organism_id and header[2] != organism_id:
+        raise AssertionError("There are multiple target organisms in the given fasta file.")
+
+    return header[2]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("fasta_file", type=str, nargs="?",
+        metavar = "<batch.fasta>",
+        help="File path to FASTA file containing a batch of consensus genomes")
+
+    args = parser.parse_args()
+    fasta_to_json(args.fasta_file)

--- a/scripts/id_barcode_key_value.py
+++ b/scripts/id_barcode_key_value.py
@@ -3,7 +3,7 @@ Generate NWGC sample ID and SFS barcode key-value pairs
 """
 import os, sys
 import argparse
-import pandas as pd 
+import pandas as pd
 
 def create_key_value_pairs(filename: str, NWGC: str, SFS:str, output:str):
     """
@@ -31,11 +31,9 @@ if __name__=="__main__":
     parser.add_argument("output_file", type=str, nargs="?",
         metavar="Output",
         help="File path for output key/value file")
-    
-   
+
     args = parser.parse_args()
-    create_key_value_pairs(args.match_file, 
-                               args.NWGC, 
-                               args.SFS, 
+    create_key_value_pairs(args.match_file,
+                               args.NWGC,
+                               args.SFS,
                                args.output_file)
-    

--- a/scripts/metadata_to_json.py
+++ b/scripts/metadata_to_json.py
@@ -1,0 +1,34 @@
+"""
+Converts a fasta file input to machine-readable, Json format. The Json document
+is printed to stdout, so the user will likely want to redirect this to a new
+file.
+"""
+import json
+import argparse
+
+def metadata_to_json(urls_r1, urls_r2):
+    urls = []
+
+    for url_set in [urls_r1, urls_r2]:
+        if url_set:
+            urls += url_set.split(" ")
+
+    print(json.dumps( {
+        "metadata": {
+            "URLs": list(set(urls))
+        }
+    }, indent=4))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("urls_r1", type=str, nargs="?",
+        metavar = "<urls_r1>")
+    parser.add_argument("urls_r2", type=str, nargs="?",
+        metavar = "<urls_r2>")
+
+    args = parser.parse_args()
+    metadata_to_json(args.urls_r1, args.urls_r2)

--- a/scripts/setup_config_file.py
+++ b/scripts/setup_config_file.py
@@ -2,7 +2,7 @@
 Edits the config file for Snakemake by filling in two fields:
 "ignored_samples" and "sample_reference_pairs".
 
-Currently need to download Excel file from Metabase that contains the 
+Currently need to download Excel file from Metabase that contains the
 NWGC sample ID and the target identifiers where present is True for the sample.
 """
 import glob
@@ -13,11 +13,11 @@ import gzip
 import pandas as pd
 from typing import Tuple
 
-def edit_config_file(file_dir: str, 
-                     config_file:str, 
+def edit_config_file(file_dir: str,
+                     config_file:str,
                      presence_file: str,
-                     sample: str, 
-                     target:str, 
+                     sample: str,
+                     target:str,
                      max_difference: int):
     """
     For all the samples listed in *file_dir*, create a dict that maps each
@@ -27,8 +27,8 @@ def edit_config_file(file_dir: str,
         reference_map = json.load(f)
     sample_target_map = create_sample_target_map(presence_file, sample, target)
     all_samples = sample_ids(file_dir)
-    
-    (sample_ref_pairs, 
+
+    (sample_ref_pairs,
      ignored_samples) = generate_config_values(all_samples,
                                                file_dir,
                                                max_difference,
@@ -44,7 +44,7 @@ def edit_config_file(file_dir: str,
         json.dump(data, f, indent=4)
 
 
-def create_sample_target_map(presence_file: str, 
+def create_sample_target_map(presence_file: str,
                              sample: str, target: str) -> dict:
     """
     Create a map of samples and targets from the given *presence_file*,
@@ -71,18 +71,18 @@ def sample_ids(file_dir: str) -> set:
     return samples
 
 
-def generate_config_values(all_samples: set, 
-                           file_dir: str, 
-                           max_diff: int, 
-                           sample_target_map: dict, 
+def generate_config_values(all_samples: set,
+                           file_dir: str,
+                           max_diff: int,
+                           sample_target_map: dict,
                            ref_map: dict) -> Tuple[dict, set]:
     """
     Generates the sample_reference_pairs dict and ignored_samples set.
 
     Samples are added to ignored_samples if read difference between R1 and
     R2 is greater than *max_diff* or if the sample cannot be found in the
-    *sample_target_map*. 
-    
+    *sample_target_map*.
+
     The sample_reference_pairs is made using the *sample_target_map* and
     the *ref_map* for the remaining samples.
     """
@@ -103,7 +103,7 @@ def generate_config_values(all_samples: set,
             for target in target_list:
                 config_targets.update(ref_map[target])
             sample_reference_pairs[sample] = list(config_targets)
-    
+
     return (sample_reference_pairs, ignored_samples)
 
 
@@ -112,7 +112,7 @@ def sample_reads_pair(file_dir: str, sample: str, max_diff: int) -> bool:
     """
     Check all *sample* files in *file_dir* to ensure reads are paired.
 
-    Returns True if the difference between R1 and R2 is 
+    Returns True if the difference between R1 and R2 is
     less than or equal to the *max_diff*
     """
     print(f"Sample: {sample}")
@@ -130,7 +130,7 @@ def check_r1_r2_reads(r1: str , r2: str) -> int:
     """
     Checks the difference between the reads in R1 and R2.
 
-    Returns the percent different as an int. 
+    Returns the percent different as an int.
     """
     r1_read_ids = find_read_ids(r1)
     r2_read_ids = find_read_ids(r2)
@@ -142,7 +142,7 @@ def check_r1_r2_reads(r1: str , r2: str) -> int:
     print(f"R1 and R2 reads differ by {percent_different}%")
     print(different_read_ids)
     return percent_different
-    
+
 
 def find_read_ids(fastq_file: str) -> set:
     """
@@ -186,14 +186,11 @@ if __name__ == "__main__":
         metavar="Max percent difference",
         default=20,
         help="The maximum difference acceptable between R1 and R2 reads")
-    
-   
-    try:
-        args = parser.parse_args()
-        edit_config_file(args.directory, args.config_file,
-                         args.sample_target_map, 
-                         args.sample, args.target,
-                         args.max_difference)
-    except:
-        parser.print_help()
-        sys.exit(0)
+
+
+
+    args = parser.parse_args()
+    edit_config_file(args.directory, args.config_file,
+                        args.sample_target_map,
+                        args.sample, args.target,
+                        args.max_difference)

--- a/scripts/setup_config_for_one_sample_target_pair.py
+++ b/scripts/setup_config_for_one_sample_target_pair.py
@@ -1,0 +1,160 @@
+"""
+Creates a config file for Snakemake for one sample/reference pair.
+"""
+import argparse
+import gzip
+import json
+
+def check_fastq_sample(fastq_files: list, nwgc_id: str):
+    """
+    Check all of the *fastq_files* provided contain the *nwgc_id*.
+    """
+    assert all(nwgc_id in filename for filename in fastq_files), \
+        f"NWGC ID {nwgc_id} was not found in all fastq filenames: {fastq_files}"
+
+
+def sort_fastq_by_lane_and_reads(fastq_files: list):
+    """
+    Sort FASTQ files by lanes so their reads can be checked in the forward
+    and reverse files.
+    """
+    fastq_by_lane = {}
+    fastq_by_read = {
+        "R1": [],
+        "R2": []
+    }
+    for filepath in fastq_files:
+        filename = filepath.split("/")[-1].split("_")
+        lane = filename[-3]
+        read = filename[-2]
+        if fastq_by_lane.get(lane):
+            fastq_by_lane[lane].update({ read: filepath })
+        else:
+            fastq_by_lane[lane] = { read: filepath }
+        fastq_by_read[read].append(filepath)
+    return fastq_by_lane, fastq_by_read
+
+
+def check_r1_r2_reads(fastq_by_lane: dict):
+    """
+    Check the R1 and R2 reads to make sure they match.
+    Prints out the difference if R1 and R2 reads don't match 100%
+    """
+    for lane in fastq_by_lane:
+        print(f"Checking reads in lane: {lane}")
+        r1_file = fastq_by_lane[lane]['R1']
+        r2_file = fastq_by_lane[lane]['R2']
+        r1_read_ids = find_read_ids(r1_file)
+        r2_read_ids = find_read_ids(r2_file)
+        different_read_ids = r1_read_ids.symmetric_difference(r2_read_ids)
+        percent_different = len(different_read_ids) / len(r1_read_ids) * 100
+        assert r1_read_ids == r2_read_ids, \
+            f"R1 and R2 reads differ by {percent_different}. Different read ids: {different_read_ids}"
+        print("100% of R1 and R2 reads are paired")
+
+
+def find_read_ids(fastq_file: str) -> set:
+    """
+    Finds all read IDs in FASTQ file and returns them as a set.
+    """
+    read_ids = set()
+    with gzip.open(fastq_file, "rt") as r1_file:
+        for line in r1_file:
+            if line.startswith("@"):
+                id = line.split()[0]
+                read_ids.add(id)
+    return read_ids
+
+
+def define_references(target: str, target_ref_map: str):
+    """
+    Uses the *target_ref_map* to determine which references map to the provided
+    *target*
+    """
+    with open(target_ref_map, 'r') as f:
+        reference_map = json.load(f)
+        f.close()
+    return reference_map[target]
+
+
+def create_barcode_match(nwgc_id: str, sfs_uuid: str):
+    """
+    Create barcode match txt file needed for the fasta header renaming.
+    """
+    barcode_match_file = f"data/{sfs_uuid}_key_value.txt"
+    with open(barcode_match_file, "w+") as f:
+        f.write(nwgc_id + "\t" + sfs_uuid)
+        f.close()
+    return barcode_match_file
+
+
+def create_config_file(config_template: str,
+                       config_file: str,
+                       fastq_by_reads: dict,
+                       nwgc_id: str,
+                       references: list,
+                       barcode_match_file: str):
+    """
+    Create a new config file for the sample/reference pair based on the
+    provided *config_template*
+    """
+    with open(config_template, "r") as template:
+        config = json.load(template)
+        template.close()
+
+    config["fastq_files"] = fastq_by_reads
+    config["references"] = references
+    config["sample"] = nwgc_id
+    config["barcode_match"] = barcode_match_file
+
+    with open(config_file, "w") as new_config:
+        new_config.seek(0)
+        new_config.truncate()
+        json.dump(config, new_config, indent=4)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--config-template", type=str,
+        metavar = "<config_template.json>",
+        help = "File path to config file template",
+        required = True)
+    parser.add_argument("--config-file", type=str,
+        metavar = "<config.json>",
+        help = "File path to config file to be used for snakemake",
+        required = True)
+    parser.add_argument("--fastq-file", type=str, nargs="+",
+        metavar = "<sample.fastq.gz>",
+        help = "File path to fastq file. Expected format of fastq filename: '346757_10DB_288_S281_L001_R1_001.fastq.gz",
+        required = True)
+    parser.add_argument("--nwgc-id", type=str, nargs="?",
+        help = "NWGC ID for the sample that matches ID in fastq filename",
+        required = True)
+    parser.add_argument("--sfs-uuid", type=str, nargs="?",
+        help = "The SFS UUID of the sample.",
+        required = True)
+    parser.add_argument("--target", type=str, nargs="?",
+        help = "The target to be used as reference in the assembly pipeline",
+        required = True)
+    parser.add_argument("--target-ref-map", type=str, nargs="?",
+        help = "The JSON file that contains the target/reference map",
+        default = "references/target_reference_map.json")
+
+    args = parser.parse_args()
+
+    # Check all fastq files are for the expected sample
+    check_fastq_sample(args.fastq_file, args.nwgc_id)
+
+    # Sort FASTQ filename by lane and by read
+    fastq_by_lane, fastq_by_reads = sort_fastq_by_lane_and_reads(args.fastq_file)
+
+    # Check all reads within one lane match in R1 and R2
+    check_r1_r2_reads(fastq_by_lane)
+
+    references = define_references(args.target, args.target_ref_map)
+    barcode_match = create_barcode_match(args.nwgc_id, args.sfs_uuid)
+    create_config_file(args.config_template, args.config_file,
+                       fastq_by_reads, args.nwgc_id, references, barcode_match)

--- a/scripts/summary_stats_to_json.py
+++ b/scripts/summary_stats_to_json.py
@@ -1,0 +1,72 @@
+"""
+Parse through Bowtie2 and BAMstats summaries given their filenames.
+"""
+import json
+import argparse
+
+def get_reads_and_align_rate(filename):
+    """
+    Parse out number of reads and align rate from bowtie2 summary log.
+    """
+    summary = {}
+    with open(filename) as f:
+        lines = f.readlines()
+        number_of_reads = lines[1].split()[0]
+        align_rate = lines[-1].split()[0]
+        f.close()
+        summary["align_rate"] = align_rate
+        summary["reads"] = number_of_reads
+
+    return summary
+
+
+def get_coverage_summary(filename):
+    """
+    Parse out mean coverage depth for each segment of the genome and add it
+    to the *bowtie_summary*.
+    """
+    summary = {}
+    with open(filename) as f:
+        lines = f.readlines()[1:]
+        segments = list(map(lambda x: x.split()[0].split('|')[-1], lines))
+        mean_coverage_depths = list(map(lambda x: float(x.split()[2]), lines))
+        coverage_summary = dict(zip(segments, mean_coverage_depths))
+        summary['mean_coverage_depths'] = coverage_summary
+
+    return summary
+
+
+def get_sample_reference_pair(filename):
+    """
+    Parse out sample id and reference name from *filename*
+    """
+    sample = filename.split('/')[-1].split('.')[0]
+    reference = filename.split('/')[-2].split('_')[0]
+    return sample, reference
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__ ,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--bowtie2", type=str, nargs="?",
+        help="bowtie2 summary file",
+        required=True)
+    parser.add_argument("--bamstats", type=str, nargs="?",
+        help="BAMstats summary file",
+        required=True)
+
+    args = parser.parse_args()
+
+    sample_id, reference_id = get_sample_reference_pair(args.bowtie2)
+    assert (sample_id, reference_id) == (get_sample_reference_pair(args.bamstats)), \
+        "The sample-reference pairs in the provided filenames do not match."
+
+    bowtie2 = get_reads_and_align_rate(args.bowtie2)
+    bamstats = get_coverage_summary(args.bamstats)
+
+    print(json.dumps({
+        'reference_organism': reference_id,
+        'summary_stats': { **bowtie2, **bamstats }
+    }, indent=4))


### PR DESCRIPTION
This PR includes changes from both #7 and #8.

1. Edits the `setup_config_file` script to create new config files rather than overwrite the template.
2. Adds a template for one sample/target configs: `one-sample-template.json`
3. Adds script `setup_config_for_one_sample_target_pair.py` to create config files for one sample/target pair. 
4. Adds `Snakefile_one_sample` specific for one sample/target pairs since there are steps in the pipeline that are unnecessary when the pipeline is provided the specific sample and target.