### PR TITLE
Backfill genome data

### DIFF
--- a/scripts/backfill_genome_data/combine_summary_and_genome.py
+++ b/scripts/backfill_genome_data/combine_summary_and_genome.py
@@ -1,0 +1,138 @@
+"""
+Combine consensus genomes with summary statistics and print them as
+newline-delimited JSON records.
+
+Records are output to stdout, you will likely want to redirect
+stdout to a file.
+"""
+import argparse
+import json
+import pandas as pd
+
+def import_nwgc_uuid_map(nwgc_uuid_file):
+    """
+    Import NWGC IDs and UUIDs as dataframe from a csv file.
+    """
+    nwgc_uuid = pd.read_excel(nwgc_uuid_file,
+                            usecols=["sample", "uuid"],
+                            dtype={"sample": "str"}) \
+                  .drop_duplicates(subset="sample")
+    nwgc_uuid.set_index("sample", inplace=True)
+    nwgc_uuid_map = nwgc_uuid.to_dict()["uuid"]
+    return nwgc_uuid_map
+
+
+def combine_summary_and_sets(sequence_read_set_file, summary_file):
+    """
+    Combine sequence read sets with assembly generated summaries.
+    """
+    summaries = {}
+    with open(summary_file) as f:
+        for line in f:
+            summary = json.loads(line)
+            sample = summary.pop("sample")
+            reference_organism = summary.pop("reference").lower()
+            if summaries.get(sample):
+                if summaries[sample].get(reference_organism):
+                    summaries[sample][reference_organism]["summary_stats"] = summary
+                else:
+                    summaries[sample].update({reference_organism: {
+                        "summary_stats": summary
+                    }})
+            else:
+                summaries[sample]={reference_organism: {"summary_stats": summary}}
+        f.close()
+    with open(sequence_read_set_file) as f:
+        for line in f:
+            read_set = json.loads(line)
+            sample = read_set.pop("sample")
+            read_set["urls"] = read_set.pop("urls")
+            if summaries.get(sample):
+                summaries[sample].update({'metadata': read_set})
+            else:
+                continue
+    return summaries
+
+
+def convert_nwgc_to_uuid(summary, nwgc_uuid_map):
+    """
+    Convert the NWGC IDs to SFS UUIDs within *summary* using the
+    *nwgc_uuid_map*.
+    """
+    for sample in summary.fromkeys(summary):
+        uuid = nwgc_uuid_map[sample]
+        summary[uuid] = summary.pop(sample)
+    return summary
+
+def combine_genome_sequences(consensus_file):
+    """
+    Combine single sequence records into one genome based on the
+    sample UUID and the reference organism.
+    """
+    combined_genomes = {}
+    with open(consensus_file) as f:
+        for line in f:
+            sequence = json.loads(line)
+            uuid = sequence.pop("sample_identifier")
+            reference_organism = sequence.pop("organism").lower()
+            if combined_genomes.get(uuid):
+                if combined_genomes[uuid].get(reference_organism):
+                    combined_genomes[uuid][reference_organism]["masked_consensus"].append(sequence)
+                else:
+                    combined_genomes[uuid].update({reference_organism: {"masked_consensus": [sequence]}})
+            else:
+                combined_genomes.update({uuid: {reference_organism: {"masked_consensus": [sequence]}}})
+        f.close()
+    return combined_genomes
+
+
+def print_summary_and_genomes(summary, genome):
+    """
+    Prints out consensus genomes with summary data and sequence read set urls
+    as newline-delimited JSON records.
+    """
+    for sample in summary:
+        for ref in summary[sample]:
+            if ref == "metadata":
+                continue
+            final = {
+                "sample_identifier": sample,
+                "reference_organism": ref,
+                "metadata": summary[sample]["metadata"]
+            }
+            if genome.get(sample) and genome[sample].get(ref):
+                final.update({"status": "complete"})
+                # Add summary statistics
+                final.update(summary[sample][ref])
+                # Add genomic sequences
+                final.update(genome[sample][ref])
+            else:
+                final.update({"status": "notMapped"})
+            print(json.dumps(final))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--sequence-read-set", type=str,
+        help="ndjson file with sequence read sets",
+        required = True)
+    parser.add_argument("--summary", type=str,
+        help="ndjson file with assembly summary statistics",
+        required=True)
+    parser.add_argument("--consensus", type=str,
+        help="ndjson file with consensus genomes",
+        required=True)
+    parser.add_argument("--nwgc-uuid", type=str,
+        help="Excel file containing map between NWGC ID and SFS UUID",
+        required=True)
+
+    args = parser.parse_args()
+
+    nwgc_uuid_map = import_nwgc_uuid_map(args.nwgc_uuid)
+    combined_summary = combine_summary_and_sets(args.sequence_read_set, args.summary)
+    assembly_summary = convert_nwgc_to_uuid(combined_summary, nwgc_uuid_map)
+    combined_genomes = combine_genome_sequences(args.consensus)
+    print_summary_and_genomes(assembly_summary, combined_genomes)

--- a/scripts/backfill_genome_data/fasta_to_ndjson.py
+++ b/scripts/backfill_genome_data/fasta_to_ndjson.py
@@ -1,0 +1,47 @@
+"""
+Converts a batch FASTA file into newline-delimited JSON file, where each line
+is a record of one sequence.
+
+Sequences are output to stdout, you will likely want to redirect
+stdout to a file.
+"""
+import json
+import argparse
+from Bio import SeqIO
+
+
+def fasta_to_ndjson(fasta_file):
+    """
+    Prints each sequence as a newline-delimited JSON record.
+    """
+    consensus_genomes = list(SeqIO.parse(fasta_file, "fasta"))
+
+    for segment in consensus_genomes:
+        header = segment.id.split("|")
+        sample_identifier = header[0]
+        sequence_identifier = header[1]
+        organism = header[2]
+        sequence_segment = header[3]
+        sequence = str(segment.seq)
+        genome_data = {
+            "sample_identifier": sample_identifier,
+            "sequence_identifier": sequence_identifier,
+            "organism": organism,
+            "sequence_segment": sequence_segment,
+            "genomic_sequence": sequence
+        }
+        print(json.dumps(genome_data))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--fasta-file",
+        type=argparse.FileType('r'),
+        metavar = "<batch.fasta>",
+        help="File path to FASTA file containing a batch of consensus genomes")
+
+    args = parser.parse_args()
+    fasta_to_ndjson(args.fasta_file)

--- a/scripts/backfill_genome_data/parse_summary_data.py
+++ b/scripts/backfill_genome_data/parse_summary_data.py
@@ -1,0 +1,101 @@
+"""
+Parse through Bowtie2 and BAMstats summaries given their directory paths and
+print them as newline-delimited JSON records.
+
+Summary records are output to stdout, you will likely want to redirect
+stdout to a file.
+"""
+import glob
+import json
+import argparse
+
+def get_reads_and_align_rate(directory):
+    """
+    Parse out number of reads and align rate from bowtie2 summary log.
+    """
+    summary = {}
+    filepath = directory + "/*/*.log"
+    for filename in glob.glob(filepath):
+        sample, reference = get_sample_reference_pair(filename)
+        default = {"align_rate": None, "reads": None}
+        if summary.get(sample):
+            summary[sample][reference] = default
+        else:
+            summary[sample] = { reference: default }
+        with open(filename) as f:
+            lines = f.readlines()
+            if len(lines) > 1:
+                number_of_reads = lines[1].split()[0]
+                align_rate = lines[-1].split()[0]
+                summary[sample][reference]["align_rate"] = align_rate
+                summary[sample][reference]["reads"] = number_of_reads
+            f.close()
+
+    return summary
+
+
+def get_sample_reference_pair(filename):
+    """
+    Parse out sample id and reference name from *filename*
+    """
+    sample = filename.split('/')[-1].split('.')[0]
+    reference = filename.split('/')[-2].split('_')[0]
+    return sample, reference
+
+
+def get_coverage_summary(directory, bowtie_summary):
+    """
+    Parse out mean coverage depth for each segment of the genome and add it
+    to the *bowtie_summary*.
+    """
+    summary = bowtie_summary if bowtie_summary else {}
+    filepath = directory + "/*/*.coverage_stats.txt"
+    for filename in glob.glob(filepath):
+        sample, reference = get_sample_reference_pair(filename)
+        default = {"mean_coverage_depths": None}
+        if summary.get(sample):
+            summary[sample][reference].update(default)
+        else:
+            summary[sample] = { reference: default }
+        with open(filename) as f:
+            lines = f.readlines()[1:]
+            segments = list(map(lambda x: x.split()[0].split('|')[-1],
+                                lines))
+            mean_coverage_depths = list(map(lambda x: float(x.split()[2]),
+                                            lines))
+            coverage_summary = dict(zip(segments, mean_coverage_depths))
+            summary[sample][reference]['mean_coverage_depths'] = coverage_summary
+    return summary
+
+
+def print_summary_as_ndjson(summary):
+    """
+    Print out summary in newline-delimited format
+    """
+    for sample in summary:
+        sample_id = sample
+        for target in summary[sample]:
+            reference = target
+            summary_stats = summary[sample][reference]
+            summary_stats['sample'] = sample_id
+            summary_stats['reference'] = reference
+            print(json.dumps(summary_stats))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description = __doc__ ,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--bowtie2", type=str,
+        help="Directory of bowtie2 summaries",
+        required=True)
+    parser.add_argument("--bamstats", type=str,
+        help="Directory of BAMstats summaries",
+        required=True)
+
+    args = parser.parse_args()
+
+    bowtie_summary = get_reads_and_align_rate(args.bowtie2)
+    bowtie_and_bamstats_summary = get_coverage_summary(args.bamstats, bowtie_summary)
+    print_summary_as_ndjson(bowtie_and_bamstats_summary)

--- a/scripts/backfill_genome_data/sequence_read_sets.py
+++ b/scripts/backfill_genome_data/sequence_read_sets.py
@@ -29,6 +29,9 @@ def find_fasta_urls(fastq_directory, filename_pattern, url_prefix) -> dict:
     filename_pattern = re.compile(filename_pattern)
 
     for filepath in list(Path(fastq_directory).glob("*.fastq.gz")):
+        # Skip the Undetermined FASTQ files
+        if filepath.name.startswith("Undetermined"):
+            continue
         filename = filepath.name
         # Check the filename matches provided filename pattern
         filename_match = filename_pattern.match(filename)

--- a/scripts/backfill_genome_data/sequence_read_sets.py
+++ b/scripts/backfill_genome_data/sequence_read_sets.py
@@ -1,0 +1,90 @@
+"""
+Find all fastq.gz files within a provided directory and group them by samples
+into sequence read sets.
+
+All sequence read sets are output to stdout as newline-delimited JSON
+records.  You will likely want to redirect stdout to a file.
+"""
+import json
+import os
+import re
+import argparse
+from collections import defaultdict
+from urllib.parse import urljoin
+from pathlib import Path
+
+def find_fasta_urls(fastq_directory, filename_pattern, url_prefix) -> dict:
+    """
+    Find all *.fastq.gz files within provided *fastq_directory*.
+
+    The provided --filename-pattern regular expression is used to extract the
+    sample ID from each FASTQ filename.  The regex should contain a capture
+    group named "sample".  Each set of files with the same sample ID are
+    grouped into a single sequence read set.
+
+    Return as a dict with keys as NWGC sample IDs and values as an array of
+    file paths.
+    """
+    sequence_read_sets = defaultdict(list)
+    filename_pattern = re.compile(filename_pattern)
+
+    for filepath in list(Path(fastq_directory).glob("*.fastq.gz")):
+        filename = filepath.name
+        # Check the filename matches provided filename pattern
+        filename_match = filename_pattern.match(filename)
+        assert filename_match, f"Filename {filename} doesn't match provided --filename-pattern"
+
+        # Extract the sample from the filename_match
+        try:
+            sample = filename_match.group("sample")
+        except IndexError:
+            print(f"Filename {filename} matched provided --filename-pattern, but didn't extract a «sample» capture group")
+            raise
+
+        sequence_read_sets[sample].append(urljoin(url_prefix, str(filepath)))
+
+    return sequence_read_sets
+
+
+def dump_ndjson(sequence_read_set_dict):
+    """
+    Prints sequence read sets as newline-delimited JSON records.
+    """
+    for sample in sequence_read_set_dict:
+        print(json.dumps({"sample": sample, "urls": sequence_read_set_dict[sample]}))
+
+
+def dir_path(directory: str):
+    """
+    Confirm that the path for given *directory* is valid.
+    """
+    if os.path.isdir(directory):
+        return directory
+    else:
+        raise NotADirectoryError(directory)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--fastq-directory",
+        metavar="<FASTQ directory>",
+        type=dir_path,
+        required=True,
+        help="Absolute file path to directory that holds *.fastq.gz files")
+    parser.add_argument("--filename-pattern",
+        metavar="<regex>",
+        default=r'^(?P<sample>\d+)_',
+        help="Regex pattern to match sample in expected filename")
+    parser.add_argument("--url-prefix",
+        metavar="<url>",
+        default = "file://rhino.fhcrc.org",
+        help="Base for fully-qualifying sequence read set URLs")
+
+    args = parser.parse_args()
+    sequence_read_sets = find_fasta_urls(args.fastq_directory,
+                                         args.filename_pattern,
+                                         args.url_prefix)
+    dump_ndjson(sequence_read_sets)


### PR DESCRIPTION
Adds scripts necessary to parse through previously generated genomic data that have not been uploaded to ID3C. 

The process would be as follows:
1. Parse sequence reads sets and upload them via `id3c sequence-read-set upload`.
2. Convert batch FASTA files to ndjson
3. Parse assembly summary data
4. Combine all three (sequence_read_set.ndjson, consensus_genome.ndjson, summary.ndjson)
5. Upload the final ndjson file via `id3c consensus-genome upload`. 