### PR TITLE
fix: fasta_headers rule race condition

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -475,15 +475,15 @@ rule fasta_headers:
         """
         cat {input.masked_consensus} | \
             perl -pi -e 's/(?<=>)[^>|]*(?<=|)/{wildcards.sample}/g' > \
-            temp_{wildcards.sample}.fasta
+            {output.masked_consensus}.temp
         seqkit replace -p '({wildcards.sample})' -r '{{kv}}' \
             -k {input.key_value_file} --keep-key \
-            temp_{wildcards.sample}.fasta > {output.masked_consensus}
+            {output.masked_consensus}.temp > {output.masked_consensus}
         awk '{{split(substr($0,2),a,"|"); \
             if(a[2]) print ">"a[1]"|"a[1]"-"a[2]"-"a[3]"|"a[2]"|"a[3]; \
             else print; }}' \
-            {output.masked_consensus} > temp_{wildcards.sample}.fasta
-        mv temp_{wildcards.sample}.fasta {output.masked_consensus}
+            {output.masked_consensus} > {output.masked_consensus}.temp
+        mv {output.masked_consensus}.temp {output.masked_consensus}
 
         """
 


### PR DESCRIPTION
Make temp file in `fasta_headers` rule specific to the 
reference/sample pair so we that we don't run into race
conditions during parallel jobs of the same sample