### PR TITLE
Mpileup2cns

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ Generates [Pileup](https://en.wikipedia.org/wiki/Pileup_format) for BAM file usi
   * `-A` to not discard anomalous read pairs
   * `-Q` to set the minimum base quality to consider a read (set to match the minimum in `varscan mpileup2snp` so that their coverage depths match)
 
-### 11. Call SNPs
-Calls SNPs from the Pileup based on parameters set in the config file using [varscan mpileup2snp](http://varscan.sourceforge.net/using-varscan.html#v2.3_mpileup2snp)
+### 11. Call Consensus
+Calls consensus (SNPs/indels) from the Pileup based on parameters set in the config file using [varscan mpileup2cns](http://varscan.sourceforge.net/using-varscan.html#v2.3_mpileup2cns)
 
 ### 12. Zip VCF
 Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it.

--- a/README.md
+++ b/README.md
@@ -177,35 +177,30 @@ Generates [Pileup](https://en.wikipedia.org/wiki/Pileup_format) for BAM file usi
   * `-A` to not discard anomalous read pairs
   * `-Q` to set the minimum base quality to consider a read (set to match the minimum in `varscan mpileup2snp` so that their coverage depths match)
 
-### 11. Call Consensus
-Calls consensus (SNPs/indels) from the Pileup based on parameters set in the config file using [varscan mpileup2cns](http://varscan.sourceforge.net/using-varscan.html#v2.3_mpileup2cns)
-
-### 12. Zip VCF
-Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it.
-
-### 13. Index BCF
-Creates index for compressed VCF using [bcftools index](https://samtools.github.io/bcftools/bcftools.html#index). This index is necessary for creating the consensus genome using the compressed VCF.
-
-### 14. VCF to consensus
-Create consensus genome by applying VCF variants to the reference genome using [bcftools consensus](https://samtools.github.io/bcftools/bcftools.html#consensus). This does not account for coverage, so it will just fill in blanks with the base from the reference genome.
-
-### 15. Create bed file
+### 11. Create bed file
 Creates a BED file for positions that need to be masked in the consensus genome. Positions need to be masked if they are below the minimum coverage depth.
 
-### 16. Mask consensus
-Masks the consensus genome with "N" at bases where coverage is below the `min_cov` parameter using [bedtools maskfasta](https://bedtools.readthedocs.io/en/latest/content/tools/maskfasta.html).
+### 12. Call Consensus
+Calls consensus (SNPs/indels) from the Pileup based on parameters set in the config file using [varscan mpileup2cns](http://varscan.sourceforge.net/using-varscan.html#v2.3_mpileup2cns)
 
-### 17. FASTA headers
+### 13. Zip VCF
+Compress VCF using [bgzip](http://www.htslib.org/doc/bgzip.html), which allows indexes to be built against the file and allows the file be used without decompressing it.
+
+### 14. Index BCF
+Creates index for compressed VCF using [bcftools index](https://samtools.github.io/bcftools/bcftools.html#index). This index is necessary for creating the consensus genome using the compressed VCF.
+
+### 15. VCF to consensus
+Create consensus genome by applying VCF variants to the reference genome using [bcftools consensus](https://samtools.github.io/bcftools/bcftools.html#consensus).
+This does not account for coverage, so we pass it the BEDfile of low coverage sites with the `--mask` option to mask these sites with `N`.
+
+### 16. FASTA headers
 Edits the FASTA headers to fit the pattern needed for downstream analysis.
 Example FASTA header: `>SFS-UUID|SFS-UUID-PB2|H1N1pdm|PB2`
 1. Replace reference sequence name with the NWGC sample ID using Perl to perform "lookaround" regex matches
 2. Uses [seqkit replace](https://bioinf.shenwei.me/seqkit/usage/#replace) to replace the NWGC sample ID with the SFS UUID.
 3.  Create the UUID-gene combination using AWK
 
-### 18. Combined FASTA
-Creates the final combined FASTA file that will have all the consensus genomes generated in a day.
-
-### 19. Aggregate
+### 17. Aggregate
 This is the last rule of the pipeline that prints out the final result of each sample/reference pair. If a consensus genome is generated, then this will also add it to the final combined FASTA.
 
 The input of this rule differs based on the result of the checkpoint, so this rule dictates the final outcome of each sample/reference pair.

--- a/Snakefile
+++ b/Snakefile
@@ -69,7 +69,7 @@ rule nwgc_sfs_map:
 rule fasta_headers:
     input:
         key_value_file = rules.nwgc_sfs_map.output,
-        masked_consensus = rules.mask_consensus.output
+        masked_consensus = rules.vcf_to_consensus.output
     output:
         masked_consensus = "consensus_genomes/{reference}/{sample}.masked_consensus.fasta"
     shell:

--- a/Snakefile-base
+++ b/Snakefile-base
@@ -258,6 +258,23 @@ rule pileup:
             -f {input.reference}
         """
 
+rule create_bed_file:
+    input:
+        pileup = rules.pileup.output.pileup
+    output:
+        bed_file = "summary/low_coverage/{reference}/{sample}.bed"
+    params:
+        min_cov = config["params"]["varscan"]["min_cov"],
+        min_freq = config["params"]["varscan"]["snp_frequency"]
+    shell:
+        """
+        python scripts/create_bed_file_for_masking.py \
+            --pileup {input.pileup} \
+            --min-cov {params.min_cov} \
+            --min-freq {params.min_freq} \
+            --bed-file {output.bed_file}
+        """
+
 rule call_consensus:
     input:
         pileup = rules.pileup.output.pileup
@@ -305,6 +322,7 @@ rule vcf_to_consensus:
     input:
         bcf = rules.zip_vcf.output.bcf,
         index = rules.index_bcf.output.index,
+        mask = rules.create_bed_file.output.bed_file,
         ref = "references/{reference}.fasta"
     output:
         consensus_genome = "consensus_genomes/{reference}/{sample}.consensus.fasta"
@@ -313,39 +331,9 @@ rule vcf_to_consensus:
     shell:
         """
         cat {input.ref} | \
-            bcftools consensus {input.bcf} > \
+            bcftools consensus {input.bcf} \
+                --mask {input.mask} > \
             {output.consensus_genome}
-        """
-
-rule create_bed_file:
-    input:
-        pileup = rules.pileup.output.pileup
-    output:
-        bed_file = "summary/low_coverage/{reference}/{sample}.bed"
-    params:
-        min_cov = config["params"]["varscan"]["min_cov"],
-        min_freq = config["params"]["varscan"]["snp_frequency"]
-    shell:
-        """
-        python scripts/create_bed_file_for_masking.py \
-            --pileup {input.pileup} \
-            --min-cov {params.min_cov} \
-            --min-freq {params.min_freq} \
-            --bed-file {output.bed_file}
-        """
-
-rule mask_consensus:
-    input:
-        consensus_genome = rules.vcf_to_consensus.output.consensus_genome,
-        low_coverage = rules.create_bed_file.output.bed_file
-    output:
-        masked_consensus = temp("consensus_genomes/{reference}/{sample}.temp_consensus.fasta")
-    shell:
-        """
-        bedtools maskfasta \
-            -fi {input.consensus_genome} \
-            -bed {input.low_coverage} \
-            -fo {output.masked_consensus}
         """
 
 rule clean:

--- a/Snakefile-base
+++ b/Snakefile-base
@@ -7,8 +7,8 @@ Basic steps:
     2. Map trimmed reads to each reference genomes in the reference panel using
        bowtie2 # This step may change with time
     ~3. Remove duplicate reads using Picard~
-    4. Call SNPs using varscan
-    5. Use SNPs to generate full consensus genomes for each sample x reference
+    4. Call consensus(SNPs/indels) using varscan
+    5. Use consensus to generate full consensus genomes for each sample x reference
        virus combination
     6. Compute summary statistics for each sample x refernce virus combination
 
@@ -258,7 +258,7 @@ rule pileup:
             -f {input.reference}
         """
 
-rule call_snps:
+rule call_consensus:
     input:
         pileup = rules.pileup.output.pileup
     output:
@@ -271,17 +271,19 @@ rule call_snps:
         "benchmarks/{sample}_{reference}.varscan"
     shell:
         """
-        varscan mpileup2snp \
+        varscan mpileup2cns \
             {input.pileup} \
             --min-coverage {params.min_cov} \
             --min-avg-qual {params.snp_qual_threshold} \
             --min-var-freq {params.snp_frequency} \
+            --strand-filter 0 \
+            --variants 1 \
             --output-vcf 1 > {output.vcf}
         """
 
 rule zip_vcf:
     input:
-        vcf = rules.call_snps.output.vcf
+        vcf = rules.call_consensus.output.vcf
     output:
         bcf = "process/vcfs/{reference}/{sample}.vcf.gz"
     shell:

--- a/Snakefile-ncov
+++ b/Snakefile-ncov
@@ -46,7 +46,7 @@ rule all:
 
 rule fasta_headers:
     input:
-        masked_consensus = rules.mask_consensus.output
+        masked_consensus = rules.vcf_to_consensus.output
     output:
         masked_consensus = "consensus_genomes/{reference}/{sample}.masked_consensus.fasta"
     shell:

--- a/envs/seattle-flu-environment.yaml
+++ b/envs/seattle-flu-environment.yaml
@@ -9,7 +9,6 @@ dependencies:
   - bamstats
   - bcftools
   - biopython
-  - bedtools
   - bowtie2
   - curl
   - fastqc


### PR DESCRIPTION
Use `varscan mpileup2cns` to call consensus which includes SNPs and indels. 

Now that the consensus genome may contain indels that shift the bases, the BEDfile generated for masking no longer aligns correctly. ~Change the pipeline to mask the __reference__ genome at low coverage bases. The pre-masked reference
genome is then passed to `bcftools consensus` to generate the consensus genome. This command applies VCF variants on top of the reference, so the consensus genome "inherits" the masked bases from the pre-masked reference genome.~

Change the pipeline to use the `--mask` options for `bcftool consensus` to mask low coverage sites. This command masks the sites first before applying variants. 

---
TO DO:
- [x] test run on latest batch of sequences