### PR TITLE
Add option for pipeline to accept fastq files that are already pooled/lane-merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Using [bowtie2-build](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#the
 
 ### 2. Merge lanes
 Concatenates 8 FASTQ files for each sample into 2 files (R1 and R2).
+This step is skipped if the fastq files are already pooled (lane merged).
 
 ### 3. Trim fastqs
 Trim raw FASTQ files with [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic), which cuts out adapter/illumina-specific sequences, trims the reads based on quality scores, and removes short reads.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ conda activate seattle-flu
 
 ## Set Up
 ### FASTQ Files
+#### For pooled (lane merged) fastq files
+The pipeline expects 2 total FASTQ files for each individual sample, with one fastq file for both Read 1 (R1) and Read 2 (R2).
+
+Expected filename format: `318375_R1.fastq.gz` where `318375` is the NWGC sample ID.
+
+#### For non-pooled (not lane merged) fastq files
 The pipeline expects 8 total FASTQ files for each individual sample, with Read 1 (R1) and Read 2 (R2) from 4 different lanes.
 
 Expected filename format: `318375_S12_L001_R1_001.fastq.gz` where `318375` is the NWGC sample ID.
@@ -43,6 +49,8 @@ positional arguments:
 optional arguments:
   -h, --help       show this help message and exit
 ```
+
+*Note. the `scripts/rename_fastq.py` script isn't currently setup to accept pooled (lane merged) fastq files*
 ### Setup Config File
 By default, the pipeline will generate combinations of all samples and references and try to create consensus genomes for all combinations.
 
@@ -112,6 +120,7 @@ __Note__: Remember to add the path of the output file to the config file after r
 Currently, `config/config-flu-only.json` has the most updated version of the configuration needed to run assembly.
 
 * `fastq_directory`: the path to the directory containing the fastq files
+* `fastq_pooling`: whether or not the input fastq files are pooled (lane merged) or non-pooled (non lane merged), expects either `"not_pooled"` or `"pooled"`
 * `ignored_samples`: an object containing keys that specify samples to be ignored
 * `sample_reference_pairs`: an object containing specific sample/reference pairs, with the keys refering to the samples and an array of references as the values.
 * `barcode_match`: the path to the file containing tab-delimited key-value pairs used to replace NWGC sample IDs with SFS UUIDs

--- a/Snakefile-base
+++ b/Snakefile-base
@@ -67,11 +67,34 @@ def filter_combinator(combinator, config):
                 yield wc_comb
     return filtered_combinator
 
+def input_fastq_format(sample: str, config: dict) -> tuple:
+    """
+    Define the input fastq directory based on whether the user has input 
+    pooled (lane merged) or non-pooled (non lane merged) fastq files, based
+    on what the fastq_pooling has been set to in the *config*.
+    
+    This function will also determine all fastqs as a tuple of forward
+    and reverse within the fastq_directory in the *config*.
+
+    The fastqs are expected to have *sample* in the filename and
+    R1/R2 in the filename to differentiate forward and reverse reads.
+    """
+
+    if config['fastq_pooling'] == "not_pooled":
+        all_r1 = "process/merged/{sample}_R1.fastq.gz"
+        all_r2 = "process/merged/{sample}_R2.fastq.gz"
+    
+    if config['fastq_pooling'] == "pooled":
+        all_r1 = glob.glob('{}/*{}*R1*'.format(config['fastq_directory'], sample))
+        all_r2 = glob.glob('{}/*{}*R2*'.format(config['fastq_directory'], sample))
+
+    return all_r1, all_r2
 
 # Build static lists of reference genomes, ID's of samples, and ID -> input files
 all_references = [ v for v in  config['reference_viruses'].keys() ]
 all_ids = generate_sample_ids(config)
 mapped = {id: generate_all_files(id, config) for id in all_ids}
+input_fastq = {id: input_fastq_format(id, config) for id in all_ids}
 filtered_product = filter_combinator(product, config)
 
 #### Main pipeline
@@ -100,8 +123,8 @@ rule merge_lanes:
 
 rule trim_fastqs:
     input:
-        fastq_f = "process/merged/{sample}_R1.fastq.gz",
-        fastq_r = "process/merged/{sample}_R2.fastq.gz"
+        fastq_f = lambda wildcards: input_fastq[wildcards.sample][0],
+        fastq_r = lambda wildcards: input_fastq[wildcards.sample][1],
     output:
         trimmed_fastq_1p = "process/trimmed/{sample}.trimmed_1P.fastq",
         trimmed_fastq_2p = "process/trimmed/{sample}.trimmed_2P.fastq",

--- a/config/config-all-refs.json
+++ b/config/config-all-refs.json
@@ -1,6 +1,8 @@
 {
   "fastq_directory" :
     "test_data",
+  "fastq_pooling":
+    "not_pooled",
   "reference_viruses" :
     {
       "all_refs" : {}

--- a/config/config-flu-only.json
+++ b/config/config-flu-only.json
@@ -1,6 +1,8 @@
 {
     "fastq_directory" :
       "test_data",
+    "fastq_pooling":
+      "not_pooled",
     "ignored_samples":
       {
         "Undetermined": {}

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,8 @@
 {
   "fastq_directory" :
     "test_data",
+  "fastq_pooling":
+    "not_pooled",
   "ignored_samples":
     {
       "S0": null

--- a/config/sars-cov-2.json
+++ b/config/sars-cov-2.json
@@ -1,5 +1,6 @@
 {
     "fastq_directory": "testdata",
+    "fastq_pooling": "not_pooled",
     "ignored_samples": {
         "Undetermined": {}
     },


### PR DESCRIPTION
Hi all, thanks for developing a great pipeline!

I developed a quick feature to allow the pipeline to accept fastq files that are already pooled/lane-merged since this is the input format our fastq data during our workflow.

If it's useful, feel free to merge this feature