### PR TITLE
Add check for empty dataframe before creating final submission outputs

### DIFF
--- a/submissions/scripts/create_submissions.py
+++ b/submissions/scripts/create_submissions.py
@@ -876,6 +876,9 @@ if __name__ == '__main__':
     # Only create submissions for sequences that have status "submitted"
     submit_metadata = metadata.loc[metadata['status'] == 'submitted']
 
+    if submit_metadata.empty:
+        sys.exit(f"No new submissions:\n {metadata.groupby(['status'])['status'].count()}")
+
     create_gisaid_submission(submit_metadata, args.fasta, output_dir, batch_name, args.gisaid_username)
 
     # Only create NCBI submissions for sequences that passed VADR


### PR DESCRIPTION
If there are no new submissions (with status=`submitted`), the `create_biosample_submission`
function throws a `KeyError: "['geo_loc_name', 'isolate'] not in index")`.

This step along with `create_gisaid_submission`, and `create_genbank_submission`
don't seem necessary if there are no new submissions, so exiting preemptively with message indicating
that with a summary of the status counts.