### PR TITLE
Add Cascadia submission group

### DIFF
--- a/submissions/scripts/create_submissions.py
+++ b/submissions/scripts/create_submissions.py
@@ -24,7 +24,7 @@ from Bio import SeqIO
 
 
 base_dir = Path(__file__).resolve().parent.parent.parent
-SUBMISSION_GROUPS = ['scan', 'sfs', 'wa-doh']
+SUBMISSION_GROUPS = ['scan', 'sfs', 'wa-doh', 'cascadia']
 SFS = 'Seattle Flu Study'
 IDENTIFIER_COLUMNS = [
     'nwgc_id',
@@ -118,8 +118,9 @@ def parse_metadata(metadata_file: str, id3c_metadata_file: str = None) -> pd.Dat
         id3c_metadata['sequence_reason'] = id3c_metadata['sequence_reason'].fillna(value='Sentinel surveillance')
         id3c_metadata['originating_lab'] = 'Seattle Flu Study'
         id3c_metadata['submission_group'] = 'sfs'
-        # Label SCAN samples separately since they have different authors than SFS samples
-        id3c_metadata.loc[id3c_metadata['source'] == 'SCAN', 'submission_group'] = 'scan'
+        # Label SCAN and Cascadia samples separately since they have different authors than SFS samples
+        id3c_metadata.loc[id3c_metadata['source'].str.lower().str.strip() == 'scan', 'submission_group'] = 'scan'
+        id3c_metadata.loc[id3c_metadata['source'].str.lower().str.strip() == 'cascadia', 'submission_group'] = 'cascadia'
 
         # Drop rows with nwgc_id in the ID3C metadata file
         # Ensures there are no duplicate rows in the final metadata DF

--- a/submissions/source-data/authors/cascadia.txt
+++ b/submissions/source-data/authors/cascadia.txt
@@ -1,0 +1,20 @@
+Chris D. Frazar
+Jover Lee
+Erica Ryke
+Luis Gamboa
+Evan McDermot
+Jeremy Stone
+Tom Kolar
+Peter D. Han
+Thomas R. Sibley
+Melissa Truong
+Caitlin R. Wolf
+Michael Boeckh
+Janet A. Englund
+Barry R. Lutz
+Alpana Waghmare
+Cecile Viboud
+Lea M. Starita
+Jay Shendure
+Trevor Bedford
+Helen Y. Chu


### PR DESCRIPTION
Adding new submission group for Cascadia records. Authors list is a placeholder for now (copy of SFS authors
list) which was used by default for the first 8 Cascadia submissions.