### PR TITLE
Add clade 22D (Pango lineage BA.2.75) to VoCs

### DIFF
--- a/submissions/source-data/variants_of_concern.tsv
+++ b/submissions/source-data/variants_of_concern.tsv
@@ -12,4 +12,4 @@ clade	pangolin	who
 21M (Omicron)	BA.3	Omicron
 22A (Omicron)	BA.4	Omicron
 22B (Omicron)	BA.5	Omicron
-
+22D (Omicron)	BA.2.75	Omicron


### PR DESCRIPTION
This new clade was added to NextStrain on July 21, 2022 and is being added as a VoC.