### PR TITLE
Identify VoCs by clade instead of pangolin

### DIFF
--- a/submissions/scripts/create_submissions.py
+++ b/submissions/scripts/create_submissions.py
@@ -405,6 +405,9 @@ def create_voc_reports(metadata: pd.DataFrame, excluded_vocs: str,
     all_vocs_counts = voc_samples.groupby(['clade', 'clade_pangolin', 'who']).size().reset_index(name='counts')
     all_vocs_counts.to_csv(output_dir / f'{batch_name}_total_vocs.csv', index=False)
 
+    vocs_by_source = voc_samples.groupby(['clade', 'clade_pangolin', 'source']).size().reset_index(name='counts')
+    vocs_by_source.to_csv(output_dir / f'{batch_name}_total_vocs_by_source.tsv', index=False, sep='\t')
+
     voc_report_columns = ['who', 'clade', 'clade_pangolin', 'pangolin', 'collection_date', 'sfs_sample_barcode', 'sfs_collection_barcode']
     sfs_vocs = voc_samples.loc[voc_samples['originating_lab'] == 'Seattle Flu Study']
     sfs_sources = sfs_vocs['source'].unique()


### PR DESCRIPTION
The existing logic for generating VoC reports and tallies relies on matching pangolin values
between the `variants_of_concern.tsv` file, and the pangolin values that were generated by
NextClade. This results in only records with exact pangolin matches being included in the outputs.

To include records matching all pangolins for each VoC, the logic is being updated to match on clade
rather than pangolin. This will include all records that NextClade identified as belonging to each
VoC clade and their specific pangolin values from NextClade.