### PR TITLE
Fix bcftools errors

### DIFF
--- a/Snakefile-base-cri
+++ b/Snakefile-base-cri
@@ -356,8 +356,8 @@ rule vcf_to_consensus:
     shell:
         f"""
         mkdir -p "{work_dir}/{assembly_subdir}/consensus_genomes/{{wildcards.reference}}"
-        cat {{input.ref}} | \
             bcftools consensus {{input.bcf}} \
+                --fasta-ref {{input.ref}} \
                 --mask {{input.mask}} > \
             {{output.consensus_genome}}
         """

--- a/Snakefile-cri
+++ b/Snakefile-cri
@@ -38,14 +38,6 @@ rule all:
         bamstats = expand(f"{work_dir}/{assembly_subdir}/summary/bamstats/{{reference}}/{{sample}}.coverage_stats.txt", filtered_product,
             sample=all_ids,
             reference=all_references),
-        consensus_genomes = expand(f"{work_dir}/{assembly_subdir}/consensus_genomes/{{reference}}/{{sample}}.consensus.fasta", filtered_product,
-            sample=all_ids,
-            reference=all_references
-        ),
-        #masked_consensus_genomes = expand(f"{work_dir}/{assembly_subdir}/consensus_genomes/{{reference}}/{{sample}}.masked_consensus.fasta", filtered_product,
-        #    sample=all_ids,
-        #    reference=all_references
-        #),
         aggregate = expand(f"{work_dir}/{assembly_subdir}/summary/aggregate/{{reference}}/{{sample}}.log", filtered_product,
                 sample=all_ids,
                 reference=all_references),


### PR DESCRIPTION
Resolves Signal 13 error in bcftools consensus by passing reference fasta as a command line option instead of piping from cat.
Resolves error in index bcf by moving mapping checkpoint to before pileup creation. This prevents empty pileups and vcfs being created for samples that do not map to the reference.